### PR TITLE
Jetbrains.sdk.2019.3

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -5,7 +5,7 @@
 
 var target = Argument("target", "Default");
 var buildConfiguration = Argument("buildConfig", "Debug");
-var waveVersion = Argument("wave", "[192.0]");
+var waveVersion = Argument("wave", "[193.0]");
 var host = Argument("Host", "Resharper");
 
 var solutionName = "ReSharper.Structured.Logging";

--- a/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.Rider.csproj
+++ b/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.Rider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <VersionPrefix>2019.2.0</VersionPrefix>
+    <VersionPrefix>2019.3.0</VersionPrefix>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup>
@@ -10,7 +10,7 @@
     <RootNamespace>ReSharper.Structured.Logging</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK" Version="2019.2.0" />
+    <PackageReference Include="JetBrains.Rider.SDK" Version="2019.3.0" />
   </ItemGroup>
   <PropertyGroup>
     <OutputPath>bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>

--- a/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.csproj
+++ b/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <VersionPrefix>2019.2.0</VersionPrefix>
+    <VersionPrefix>2019.3.0</VersionPrefix>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.2.0" />
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.3.0" />
   </ItemGroup>
   <PropertyGroup>
     <OutputPath>bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>

--- a/test/data/Analyzers/CorrectExceptionPassing/SerilogIncorrectExceptionPassingDynamicTemplate.cs.gold
+++ b/test/data/Analyzers/CorrectExceptionPassing/SerilogIncorrectExceptionPassingDynamicTemplate.cs.gold
@@ -13,6 +13,6 @@ namespace ConsoleApp
 }
 
 ---------------------------------------------------------
-(0): ReSharper String Escape Character 1: 
-(1): ReSharper String Escape Character 1: 
+(0): ReSharper C# Escape Character 1: 
+(1): ReSharper C# Escape Character 1: 
 (2): ReSharper Warning: Exception should be passed to the exception argument

--- a/test/data/Analyzers/TemplateFormat/SerilogTemplateWithEscapedSymbols.cs.gold
+++ b/test/data/Analyzers/TemplateFormat/SerilogTemplateWithEscapedSymbols.cs.gold
@@ -12,9 +12,9 @@ namespace ConsoleApp
 }
 
 ---------------------------------------------------------
-(0): ReSharper String Escape Character 1: 
-(1): ReSharper String Escape Character 2: 
+(0): ReSharper C# Escape Character 1: 
+(1): ReSharper C# Escape Character 2: 
 (2): ReSharper Format String Item: 
-(3): ReSharper String Escape Character 1: 
-(4): ReSharper String Escape Character 2: 
+(3): ReSharper C# Escape Character 1: 
+(4): ReSharper C# Escape Character 2: 
 (5): ReSharper Format String Item: 

--- a/test/src/ReSharper.Structured.Logging.Rider.Tests.csproj
+++ b/test/src/ReSharper.Structured.Logging.Rider.Tests.csproj
@@ -4,7 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2019.2.0" />
+    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2019.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ReSharper.Structured.Logging\ReSharper.Structured.Logging.Rider.csproj" />

--- a/test/src/ReSharper.Structured.Logging.Tests.csproj
+++ b/test/src/ReSharper.Structured.Logging.Tests.csproj
@@ -4,7 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2019.2.0" />
+    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2019.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ReSharper.Structured.Logging\ReSharper.Structured.Logging.csproj" />


### PR DESCRIPTION
Updates the package references for resharper 2019.3.
I was able to build the nuget package by the build.cake and it works fine after installing it :)