### PR TITLE
Rider 2020.3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ Look for `Structured Logging` in Settings -> Plugins -> Browse repositories.
 
 ## Credits
 
-Inpired by [SerilogAnalyzer](https://github.com/Suchiman/SerilogAnalyzer)
+Inspired by [SerilogAnalyzer](https://github.com/Suchiman/SerilogAnalyzer)

--- a/build.cake
+++ b/build.cake
@@ -6,7 +6,7 @@
 var target = Argument("target", "Default");
 var buildConfiguration = Argument("buildConfig", "Debug");
 
-var waveVersion = Argument("wave", "202");
+var waveVersion = Argument("wave", "203");
 var waveNugetVersion = $"[{waveVersion}.0]";
 var host = Argument("Host", "Resharper");
 

--- a/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.Rider.csproj
+++ b/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.Rider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <VersionPrefix>2020.3.0-eap10</VersionPrefix>
+    <VersionPrefix>2020.3.0</VersionPrefix>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup>
@@ -10,7 +10,7 @@
     <RootNamespace>ReSharper.Structured.Logging</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK" Version="2020.3.0-eap10" />
+    <PackageReference Include="JetBrains.Rider.SDK" Version="2020.3.0" />
   </ItemGroup>
   <PropertyGroup>
     <OutputPath>bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>

--- a/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.Rider.csproj
+++ b/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.Rider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <VersionPrefix>2020.2.1</VersionPrefix>
+    <VersionPrefix>2020.3.1</VersionPrefix>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup>
@@ -10,7 +10,7 @@
     <RootNamespace>ReSharper.Structured.Logging</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK" Version="2020.2.1" />
+    <PackageReference Include="JetBrains.Rider.SDK" Version="2020.2.4" />
   </ItemGroup>
   <PropertyGroup>
     <OutputPath>bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>

--- a/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.Rider.csproj
+++ b/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.Rider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <VersionPrefix>2020.3.1</VersionPrefix>
+    <VersionPrefix>2020.3.0-eap10</VersionPrefix>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup>
@@ -10,7 +10,7 @@
     <RootNamespace>ReSharper.Structured.Logging</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK" Version="2020.2.4" />
+    <PackageReference Include="JetBrains.Rider.SDK" Version="2020.3.0-eap10" />
   </ItemGroup>
   <PropertyGroup>
     <OutputPath>bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>

--- a/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.csproj
+++ b/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <VersionPrefix>2020.2.1</VersionPrefix>
+    <VersionPrefix>2020.3.1</VersionPrefix>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.2.1" />
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.2.4" />
   </ItemGroup>
   <PropertyGroup>
     <OutputPath>bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>

--- a/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.csproj
+++ b/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <VersionPrefix>2020.3.0-eap10</VersionPrefix>
+    <VersionPrefix>2020.3.0</VersionPrefix>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.3.0-eap10" />
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.3.0" />
   </ItemGroup>
   <PropertyGroup>
     <OutputPath>bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>

--- a/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.csproj
+++ b/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <VersionPrefix>2020.3.1</VersionPrefix>
+    <VersionPrefix>2020.3.0-eap10</VersionPrefix>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.2.4" />
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.3.0-eap10" />
   </ItemGroup>
   <PropertyGroup>
     <OutputPath>bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>

--- a/src/rider-structured-logging/META-INF/plugin.xml
+++ b/src/rider-structured-logging/META-INF/plugin.xml
@@ -2,7 +2,7 @@
   <id>com.intellij.resharper.StructuredLogging</id>
   <name>Structured Logging</name>
   <description>Provides highlighting for structured logging message templates and contains some useful analyzers. Supports Serilog, NLog, and Microsoft.Extensions.Logging.</description>
-  <version>2020.3.1</version>
+  <version>2019.1.1.0</version>
   <vendor url="https://github.com/olsh/resharper-structured-logging">Oleg Shevchenko</vendor>
   <idea-version since-build="203" until-build="203.*"/>
   <extensions defaultExtensionNs="com.intellij" />

--- a/src/rider-structured-logging/META-INF/plugin.xml
+++ b/src/rider-structured-logging/META-INF/plugin.xml
@@ -4,7 +4,7 @@
   <description>Provides highlighting for structured logging message templates and contains some useful analyzers. Supports Serilog, NLog, and Microsoft.Extensions.Logging.</description>
   <version>2019.1.1.0</version>
   <vendor url="https://github.com/olsh/resharper-structured-logging">Oleg Shevchenko</vendor>
-  <idea-version since-build="203" until-build="203.*"/>
+  <idea-version since-build="202" until-build="202.*"/>
   <extensions defaultExtensionNs="com.intellij" />
   <depends>com.intellij.modules.rider</depends>
 </idea-plugin>

--- a/src/rider-structured-logging/META-INF/plugin.xml
+++ b/src/rider-structured-logging/META-INF/plugin.xml
@@ -2,9 +2,9 @@
   <id>com.intellij.resharper.StructuredLogging</id>
   <name>Structured Logging</name>
   <description>Provides highlighting for structured logging message templates and contains some useful analyzers. Supports Serilog, NLog, and Microsoft.Extensions.Logging.</description>
-  <version>2019.1.1.0</version>
+  <version>2020.3.1</version>
   <vendor url="https://github.com/olsh/resharper-structured-logging">Oleg Shevchenko</vendor>
-  <idea-version since-build="202" until-build="202.*"/>
+  <idea-version since-build="203" until-build="203.*"/>
   <extensions defaultExtensionNs="com.intellij" />
   <depends>com.intellij.modules.rider</depends>
 </idea-plugin>

--- a/test/src/ReSharper.Structured.Logging.Rider.Tests.csproj
+++ b/test/src/ReSharper.Structured.Logging.Rider.Tests.csproj
@@ -4,7 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2020.2.4" />
+    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2020.3.0-eap10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ReSharper.Structured.Logging\ReSharper.Structured.Logging.Rider.csproj" />

--- a/test/src/ReSharper.Structured.Logging.Rider.Tests.csproj
+++ b/test/src/ReSharper.Structured.Logging.Rider.Tests.csproj
@@ -4,7 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2020.3.0-eap10" />
+    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2020.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ReSharper.Structured.Logging\ReSharper.Structured.Logging.Rider.csproj" />

--- a/test/src/ReSharper.Structured.Logging.Rider.Tests.csproj
+++ b/test/src/ReSharper.Structured.Logging.Rider.Tests.csproj
@@ -4,7 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2020.2.1" />
+    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2020.2.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ReSharper.Structured.Logging\ReSharper.Structured.Logging.Rider.csproj" />

--- a/test/src/ReSharper.Structured.Logging.Tests.csproj
+++ b/test/src/ReSharper.Structured.Logging.Tests.csproj
@@ -4,7 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2020.2.1" />
+    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2020.2.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ReSharper.Structured.Logging\ReSharper.Structured.Logging.csproj" />

--- a/test/src/ReSharper.Structured.Logging.Tests.csproj
+++ b/test/src/ReSharper.Structured.Logging.Tests.csproj
@@ -4,7 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2020.3.0-eap10" />
+    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2020.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ReSharper.Structured.Logging\ReSharper.Structured.Logging.csproj" />

--- a/test/src/ReSharper.Structured.Logging.Tests.csproj
+++ b/test/src/ReSharper.Structured.Logging.Tests.csproj
@@ -4,7 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2020.2.4" />
+    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2020.3.0-eap10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ReSharper.Structured.Logging\ReSharper.Structured.Logging.csproj" />


### PR DESCRIPTION
Note: smoke test executed against JetBrains Rider 2020.3 EAP 10, build #RD-203.5981.86, built on December 2, 2020
