### PR TITLE
Update JetBrains SDK to 2021.1

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,7 +6,7 @@
 var target = Argument("target", "Default");
 var buildConfiguration = Argument("buildConfig", "Debug");
 
-var waveVersion = Argument("wave", "203");
+var waveVersion = Argument("wave", "211");
 var waveNugetVersion = $"[{waveVersion}.0]";
 var host = Argument("Host", "Resharper");
 

--- a/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.Rider.csproj
+++ b/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.Rider.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <VersionPrefix>2020.3.2</VersionPrefix>
+    <VersionPrefix>2021.1.0</VersionPrefix>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup>
@@ -10,7 +10,7 @@
     <RootNamespace>ReSharper.Structured.Logging</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK" Version="2020.3.2" />
+    <PackageReference Include="JetBrains.Rider.SDK" Version="2021.1.0" />
   </ItemGroup>
   <PropertyGroup>
     <OutputPath>bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>

--- a/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.csproj
+++ b/src/ReSharper.Structured.Logging/ReSharper.Structured.Logging.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <VersionPrefix>2020.3.2</VersionPrefix>
+    <VersionPrefix>2021.1.0</VersionPrefix>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.3.2" />
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2021.1.0" />
   </ItemGroup>
   <PropertyGroup>
     <OutputPath>bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>

--- a/src/rider-structured-logging/META-INF/plugin.xml
+++ b/src/rider-structured-logging/META-INF/plugin.xml
@@ -4,7 +4,7 @@
   <description>Provides highlighting for structured logging message templates and contains some useful analyzers. Supports Serilog, NLog, and Microsoft.Extensions.Logging.</description>
   <version>2019.1.1.0</version>
   <vendor url="https://github.com/olsh/resharper-structured-logging">Oleg Shevchenko</vendor>
-  <idea-version since-build="202" until-build="202.*"/>
+  <idea-version since-build="211" until-build="211.*"/>
   <extensions defaultExtensionNs="com.intellij" />
   <depends>com.intellij.modules.rider</depends>
 </idea-plugin>

--- a/test/src/ReSharper.Structured.Logging.Rider.Tests.csproj
+++ b/test/src/ReSharper.Structured.Logging.Rider.Tests.csproj
@@ -4,7 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2020.3.2" />
+    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2021.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ReSharper.Structured.Logging\ReSharper.Structured.Logging.Rider.csproj" />

--- a/test/src/ReSharper.Structured.Logging.Tests.csproj
+++ b/test/src/ReSharper.Structured.Logging.Tests.csproj
@@ -4,7 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2020.3.2" />
+    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2021.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ReSharper.Structured.Logging\ReSharper.Structured.Logging.csproj" />


### PR DESCRIPTION
- Update wave version to 211
- Update JetBrains.ReSharper.SDK version to 2021.1.0
- Update JetBrains.Rider.SDK version to 2021.1.0

Resolves #21