### PR TITLE
Add quick fix for contextual logger problem

### DIFF
--- a/src/ReSharper.Structured.Logging/Analyzer/ContextualLoggerConstructorAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/ContextualLoggerConstructorAnalyzer.cs
@@ -52,7 +52,12 @@ namespace ReSharper.Structured.Logging.Analyzer
                     continue;
                 }
 
-                consumer.AddHighlighting(new ContextualLoggerWarning(declaration.TypeUsage.GetDocumentRange()));
+                consumer.AddHighlighting(
+                    new ContextualLoggerWarning(
+                        declaration.TypeUsage.GetDocumentRange(),
+                        declaration.TypeUsage.GetFirstTypeArgumentNode(),
+                        containingType,
+                        declaration));
             }
         }
     }

--- a/src/ReSharper.Structured.Logging/Analyzer/ContextualLoggerSerilogFactoryAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/ContextualLoggerSerilogFactoryAnalyzer.cs
@@ -29,7 +29,11 @@ namespace ReSharper.Structured.Logging.Analyzer
                 return;
             }
 
-            consumer.AddHighlighting(new ContextualLoggerWarning(element.GetDocumentRange()));
+            consumer.AddHighlighting(
+                new ContextualLoggerWarning(
+                    element.GetDocumentRange(),
+                    element.GetFirstTypeArgumentNode(),
+                    containingNode.DeclaredElement));
         }
     }
 }

--- a/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
+++ b/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
@@ -187,6 +187,20 @@ namespace ReSharper.Structured.Logging.Extensions
             return substitution.Apply(typeParameter);
         }
 
+        [CanBeNull]
+        public static ITypeUsage GetFirstTypeArgumentNode([CanBeNull]this ITypeUsage typeUsage)
+        {
+            return (typeUsage as IUserTypeUsage)?.ScalarTypeName?.TypeArgumentList?.TypeArgumentNodes
+                .FirstOrDefault();
+        }
+
+        [CanBeNull]
+        public static ITypeUsage GetFirstTypeArgumentNode([CanBeNull]this IInvocationExpression invocationExpression)
+        {
+            return (invocationExpression?.InvokedExpression as IReferenceExpression)?.TypeArgumentList
+                ?.TypeArgumentNodes.FirstOrDefault();
+        }
+
         private static bool IsVerbatimString([CanBeNull]this IExpression expression)
         {
             return expression?.FirstChild?.NodeType == CSharpTokenType.STRING_LITERAL_VERBATIM;

--- a/src/ReSharper.Structured.Logging/Highlighting/ContextualLoggerWarning.cs
+++ b/src/ReSharper.Structured.Logging/Highlighting/ContextualLoggerWarning.cs
@@ -1,6 +1,9 @@
+using JetBrains.Annotations;
 using JetBrains.DocumentModel;
 using JetBrains.ReSharper.Feature.Services.Daemon;
+using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
 
 using ReSharper.Structured.Logging.Settings;
 
@@ -26,14 +29,34 @@ namespace ReSharper.Structured.Logging.Highlighting
 
         private readonly DocumentRange _range;
 
-        public ContextualLoggerWarning(DocumentRange documentRange)
+        public ContextualLoggerWarning(
+            DocumentRange documentRange,
+            [CanBeNull] ITypeUsage typeArgument,
+            [CanBeNull] ITypeElement expectedType,
+            [CanBeNull] ICSharpParameterDeclaration parameterDeclaration = null)
         {
             _range = documentRange;
+            TypeArgument = typeArgument;
+            ExpectedType = expectedType;
+            ParameterDeclaration = parameterDeclaration;
         }
 
         public string ErrorStripeToolTip => ToolTip;
 
+        [CanBeNull]
+        public ITypeElement ExpectedType { get; }
+
+        /// <summary>
+        /// The parameter the logger is declared on, or <c>null</c> when the warning comes from a
+        /// Serilog <c>ForContext&lt;T&gt;()</c> call.
+        /// </summary>
+        [CanBeNull]
+        public ICSharpParameterDeclaration ParameterDeclaration { get; }
+
         public string ToolTip => Message;
+
+        [CanBeNull]
+        public ITypeUsage TypeArgument { get; }
 
         public DocumentRange CalculateRange()
         {

--- a/src/ReSharper.Structured.Logging/QuickFixes/ChangeContextualLoggerTypeFix.cs
+++ b/src/ReSharper.Structured.Logging/QuickFixes/ChangeContextualLoggerTypeFix.cs
@@ -1,0 +1,230 @@
+using System.Collections.Generic;
+
+using JetBrains.Annotations;
+using JetBrains.Application.Progress;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.BulbActions;
+using JetBrains.ReSharper.Feature.Services.QuickFixes;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Tree;
+using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Resources.Shell;
+using JetBrains.Util;
+
+using ReSharper.Structured.Logging.Extensions;
+using ReSharper.Structured.Logging.Highlighting;
+
+namespace ReSharper.Structured.Logging.QuickFixes
+{
+    [QuickFix]
+    public class ChangeContextualLoggerTypeFix : ModernScopedQuickFixBase
+    {
+        private readonly ITypeElement _expectedType;
+
+        private readonly ICSharpParameterDeclaration _parameterDeclaration;
+
+        private readonly ITypeUsage _typeArgument;
+
+        public ChangeContextualLoggerTypeFix([NotNull] ContextualLoggerWarning error)
+        {
+            _typeArgument = error.TypeArgument;
+            _expectedType = error.ExpectedType;
+            _parameterDeclaration = error.ParameterDeclaration;
+        }
+
+        public override string Text => $"Change contextual logger type to '{_expectedType?.ShortName}'";
+
+        public override bool IsAvailable(IUserDataHolder cache)
+        {
+            return _typeArgument != null
+                   && _typeArgument.IsValid()
+                   && _expectedType != null
+                   && _expectedType.IsValid();
+        }
+
+        /// <inheritdoc />
+        protected override ITreeNode TryGetContextTreeNode()
+        {
+            return _typeArgument;
+        }
+
+        protected override IBulbActionCommand ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
+        {
+            // The members have to be located before anything is replaced, because rewriting the
+            // parameter type argument invalidates the reference walk used to find them.
+            var memberTypeArguments = FindAssignedMemberTypeArguments();
+
+            using (WriteLockCookie.Create())
+            {
+                ReplaceWithExpectedType(_typeArgument);
+
+                foreach (var memberTypeArgument in memberTypeArguments)
+                {
+                    ReplaceWithExpectedType(memberTypeArgument);
+                }
+            }
+
+            return null;
+        }
+
+        [CanBeNull]
+        private static string GetContextTypeName([CanBeNull] ITypeUsage typeArgument)
+        {
+            if (typeArgument == null)
+            {
+                return null;
+            }
+
+            return (CSharpTypeFactory.CreateType(typeArgument) as IDeclaredType)?.GetTypeElement()
+                ?.GetClrName()
+                .FullName;
+        }
+
+        private static bool HasSingleDeclarator([NotNull] IFieldDeclaration fieldDeclaration)
+        {
+            var multipleDeclaration = (fieldDeclaration as IMultipleDeclarationMember)?.MultipleDeclaration;
+
+            return multipleDeclaration == null || multipleDeclaration.Declarators.Count <= 1;
+        }
+
+        /// <summary>
+        /// Locates the type argument of every field or property the logger parameter is assigned to,
+        /// so that the type keeps compiling after the parameter type is changed.
+        /// </summary>
+        [NotNull]
+        private IList<ITypeUsage> FindAssignedMemberTypeArguments()
+        {
+            var result = new List<ITypeUsage>();
+            if (_parameterDeclaration == null || !_parameterDeclaration.IsValid())
+            {
+                return result;
+            }
+
+            var parameter = _parameterDeclaration.DeclaredElement;
+            var typeDeclaration = _parameterDeclaration.GetContainingNode<ITypeDeclaration>();
+            if (parameter == null || typeDeclaration == null)
+            {
+                return result;
+            }
+
+            // Only members logging the very same wrong type are rewritten. ILogger<T> is covariant,
+            // so an ILogger<object> member is legitimate and has to be left alone.
+            var wrongTypeName = GetContextTypeName(_typeArgument);
+            if (wrongTypeName == null)
+            {
+                return result;
+            }
+
+            foreach (var referenceExpression in typeDeclaration.Descendants<IReferenceExpression>())
+            {
+                if (referenceExpression.NameIdentifier?.Name != parameter.ShortName)
+                {
+                    continue;
+                }
+
+                if (!parameter.Equals(
+                        referenceExpression.Reference.Resolve()
+                            .DeclaredElement))
+                {
+                    continue;
+                }
+
+                var typeArgument = GetWrongLoggerTypeArgument(
+                    FindMemberTypeUsage(referenceExpression),
+                    wrongTypeName);
+                if (typeArgument != null && !result.Contains(typeArgument))
+                {
+                    result.Add(typeArgument);
+                }
+            }
+
+            return result;
+        }
+
+        [CanBeNull]
+        private ITypeUsage FindMemberTypeUsage([NotNull] IReferenceExpression referenceExpression)
+        {
+            // Primary constructor: private readonly ILogger<B> _log = log;
+            var initializer = ExpressionInitializerNavigator.GetByValue(referenceExpression);
+            if (initializer != null)
+            {
+                var initializedField = FieldDeclarationNavigator.GetByInitial(initializer);
+                if (initializedField != null)
+                {
+                    return HasSingleDeclarator(initializedField) ? initializedField.TypeUsage : null;
+                }
+
+                return PropertyDeclarationNavigator.GetByInitial(initializer)
+                    ?.TypeUsage;
+            }
+
+            // Regular constructor: _log = log;
+            var assignment = AssignmentExpressionNavigator.GetBySource(referenceExpression);
+            if (assignment == null || assignment.AssignmentType != AssignmentType.EQ)
+            {
+                return null;
+            }
+
+            var member = (assignment.Dest as IReferenceExpression)?.Reference.Resolve()
+                .DeclaredElement;
+
+            // Guards against assigning the logger into a member of some other type.
+            if (member == null || !_expectedType.Equals((member as IClrDeclaredElement)?.GetContainingType()))
+            {
+                return null;
+            }
+
+            foreach (var declaration in member.GetDeclarations())
+            {
+                // Never reach into another file - the quick fix only rewrites what the user can see.
+                if (declaration.GetSourceFile() != _parameterDeclaration.GetSourceFile())
+                {
+                    continue;
+                }
+
+                if (declaration is IFieldDeclaration fieldDeclaration)
+                {
+                    return HasSingleDeclarator(fieldDeclaration) ? fieldDeclaration.TypeUsage : null;
+                }
+
+                if (declaration is IPropertyDeclaration propertyDeclaration)
+                {
+                    return propertyDeclaration.TypeUsage;
+                }
+            }
+
+            return null;
+        }
+
+        [CanBeNull]
+        private static ITypeUsage GetWrongLoggerTypeArgument(
+            [CanBeNull] ITypeUsage memberTypeUsage,
+            [NotNull] string wrongTypeName)
+        {
+            if (memberTypeUsage == null)
+            {
+                return null;
+            }
+
+            if (!(CSharpTypeFactory.CreateType(memberTypeUsage) is IDeclaredType declaredType)
+                || !declaredType.IsGenericMicrosoftExtensionsLogger())
+            {
+                return null;
+            }
+
+            var typeArgument = memberTypeUsage.GetFirstTypeArgumentNode();
+
+            return wrongTypeName.Equals(GetContextTypeName(typeArgument)) ? typeArgument : null;
+        }
+
+        private void ReplaceWithExpectedType([NotNull] ITypeUsage node)
+        {
+            var factory = CSharpElementFactory.GetInstance(node, false);
+            var expectedTypeUsage = factory.CreateTypeUsage(TypeFactory.CreateType(_expectedType), node);
+
+            ModificationUtil.ReplaceChild(node, expectedTypeUsage);
+        }
+    }
+}

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftCovariantMemberIsNotChanged.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftCovariantMemberIsNotChanged.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+	ILogger<object> _log;
+
+	public A(ILogger<{caret}B> log)
+	{
+		_log = log;
+	}
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftCovariantMemberIsNotChanged.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftCovariantMemberIsNotChanged.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+	ILogger<object> _log;
+
+	public A(ILogger<A{caret}> log)
+	{
+		_log = log;
+	}
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftExpressionBodiedConstructor.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftExpressionBodiedConstructor.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+	ILogger<B> _log;
+
+	public A(ILogger<{caret}B> log) => _log = log;
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftExpressionBodiedConstructor.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftExpressionBodiedConstructor.cs.gold
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+	ILogger<A> _log;
+
+	public A(ILogger<A{caret}> log) => _log = log;
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftPrimaryConstructor.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftPrimaryConstructor.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A(ILogger<{caret}B> log)
+{
+	private readonly ILogger<B> _log = log;
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftPrimaryConstructor.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftPrimaryConstructor.cs.gold
@@ -1,0 +1,8 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A(ILogger<A{caret}> log)
+{
+	private readonly ILogger<A> _log = log;
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextType.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextType.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+	ILogger<B> _log;
+
+	public A(ILogger<{caret}B> log)
+	{
+		_log = log;
+	}
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextType.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextType.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+	ILogger<A> _log;
+
+	public A(ILogger<A{caret}> log)
+	{
+		_log = log;
+	}
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeGenericClass.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeGenericClass.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A<T>
+{
+	ILogger<B> _log;
+
+	public A(ILogger<{caret}B> log)
+	{
+		_log = log;
+	}
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeGenericClass.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeGenericClass.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A<T>
+{
+	ILogger<A<T>> _log;
+
+	public A(ILogger<A<T>{caret}> log)
+	{
+		_log = log;
+	}
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeMultipleNamespaces.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeMultipleNamespaces.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace X
+{
+	class A { }
+}
+
+namespace Y
+{
+	class A
+	{
+		ILogger<X.A> _log;
+
+		public A(ILogger<{caret}X.A> log)
+		{
+			_log = log;
+		}
+	}
+}

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeMultipleNamespaces.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeMultipleNamespaces.cs.gold
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace X
+{
+	class A { }
+}
+
+namespace Y
+{
+	class A
+	{
+		ILogger<A> _log;
+
+		public A(ILogger<{caret}A> log)
+		{
+			_log = log;
+		}
+	}
+}

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeMultipleParameters.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeMultipleParameters.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+	ILogger<B> _log;
+
+	public A(int a, ILogger<{caret}B> log)
+	{
+		_log = log;
+	}
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeMultipleParameters.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeMultipleParameters.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+	ILogger<A> _log;
+
+	public A(int a, ILogger<A{caret}> log)
+	{
+		_log = log;
+	}
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeNestedClass.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeNestedClass.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.Logging;
+
+class Outer
+{
+	public class Inner
+	{
+		ILogger<B> _log;
+
+		public Inner(ILogger<{caret}B> log)
+		{
+			_log = log;
+		}
+	}
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeNestedClass.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeNestedClass.cs.gold
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.Logging;
+
+class Outer
+{
+	public class Inner
+	{
+		ILogger<Inner> _log;
+
+		public Inner(ILogger<Inner{caret}> log)
+		{
+			_log = log;
+		}
+	}
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeProperty.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeProperty.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+	ILogger<B> Log { get; }
+
+	public A(ILogger<{caret}B> log)
+	{
+		Log = log;
+	}
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeProperty.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeProperty.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+	ILogger<A> Log { get; }
+
+	public A(ILogger<A{caret}> log)
+	{
+		Log = log;
+	}
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeWithoutField.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeWithoutField.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+	public A(ILogger<{caret}B> log)
+	{
+	}
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeWithoutField.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/MicrosoftWrongContextTypeWithoutField.cs.gold
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+	public A(ILogger<A{caret}> log)
+	{
+	}
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/RecordWrongContextType.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/RecordWrongContextType.cs
@@ -1,0 +1,5 @@
+﻿using Microsoft.Extensions.Logging;
+
+record A(ILogger<{caret}B> Log);
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/RecordWrongContextType.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/RecordWrongContextType.cs.gold
@@ -1,0 +1,5 @@
+﻿using Microsoft.Extensions.Logging;
+
+record A(ILogger<A{caret}> Log);
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/SerilogWrongContextType.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/SerilogWrongContextType.cs
@@ -1,0 +1,8 @@
+﻿using Serilog;
+
+class A
+{
+    private static readonly ILogger ContextLogger = Log.Logger.ForContext<{caret}B>();
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/SerilogWrongContextType.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/SerilogWrongContextType.cs.gold
@@ -1,0 +1,8 @@
+﻿using Serilog;
+
+class A
+{
+    private static readonly ILogger ContextLogger = Log.Logger.ForContext<A{caret}>();
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/StructWrongContextType.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/StructWrongContextType.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.Extensions.Logging;
+
+struct A(ILogger<{caret}B> log)
+{
+	private readonly ILogger<B> _log = log;
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/StructWrongContextType.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/StructWrongContextType.cs.gold
@@ -1,0 +1,8 @@
+﻿using Microsoft.Extensions.Logging;
+
+struct A(ILogger<A{caret}> log)
+{
+	private readonly ILogger<A> _log = log;
+}
+
+class B { }

--- a/test/src/QuickFixes/ChangeContextualLoggerTypeFixDotNet6Tests.cs
+++ b/test/src/QuickFixes/ChangeContextualLoggerTypeFixDotNet6Tests.cs
@@ -1,0 +1,36 @@
+using JetBrains.ReSharper.FeaturesTestFramework.Intentions;
+using JetBrains.ReSharper.TestFramework;
+
+using NUnit.Framework;
+
+using ReSharper.Structured.Logging.QuickFixes;
+using ReSharper.Structured.Logging.Tests.Constants;
+
+namespace ReSharper.Structured.Logging.Tests.QuickFixes
+{
+    [TestFixture]
+    [TestNet60]
+    [TestPackages(NugetPackages.MicrosoftLoggingPackage)]
+    public class ChangeContextualLoggerTypeFixDotNet6Tests : CSharpQuickFixTestBase<ChangeContextualLoggerTypeFix>
+    {
+        protected override string RelativeTestDataPath => @"QuickFixes\ChangeContextualLoggerTypeFix";
+
+        [Test] public void TestMicrosoftWrongContextType() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftWrongContextTypeMultipleParameters() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftWrongContextTypeMultipleNamespaces() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftWrongContextTypeWithoutField() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftWrongContextTypeProperty() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftWrongContextTypeGenericClass() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftWrongContextTypeNestedClass() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftExpressionBodiedConstructor() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftCovariantMemberIsNotChanged() => DoNamedTest2();
+    }
+}

--- a/test/src/QuickFixes/ChangeContextualLoggerTypeFixPrimaryConstructorTests.cs
+++ b/test/src/QuickFixes/ChangeContextualLoggerTypeFixPrimaryConstructorTests.cs
@@ -1,0 +1,25 @@
+using JetBrains.ReSharper.FeaturesTestFramework.Intentions;
+using JetBrains.ReSharper.TestFramework;
+
+using NUnit.Framework;
+
+using ReSharper.Structured.Logging.QuickFixes;
+using ReSharper.Structured.Logging.Tests.Constants;
+
+namespace ReSharper.Structured.Logging.Tests.QuickFixes
+{
+    [TestFixture]
+    [TestNet80]
+    [TestPackages(NugetPackages.MicrosoftLoggingPackage)]
+    public class ChangeContextualLoggerTypeFixPrimaryConstructorTests
+        : CSharpQuickFixTestBase<ChangeContextualLoggerTypeFix>
+    {
+        protected override string RelativeTestDataPath => @"QuickFixes\ChangeContextualLoggerTypeFix";
+
+        [Test] public void TestMicrosoftPrimaryConstructor() => DoNamedTest2();
+
+        [Test] public void TestRecordWrongContextType() => DoNamedTest2();
+
+        [Test] public void TestStructWrongContextType() => DoNamedTest2();
+    }
+}

--- a/test/src/QuickFixes/ChangeContextualLoggerTypeFixTests.cs
+++ b/test/src/QuickFixes/ChangeContextualLoggerTypeFixTests.cs
@@ -1,0 +1,13 @@
+using NUnit.Framework;
+
+using ReSharper.Structured.Logging.QuickFixes;
+
+namespace ReSharper.Structured.Logging.Tests.QuickFixes
+{
+    public class ChangeContextualLoggerTypeFixTests : QuickFixTestBase<ChangeContextualLoggerTypeFix>
+    {
+        protected override string SubPath => "ChangeContextualLoggerTypeFix";
+
+        [Test] public void TestSerilogWrongContextType() => DoNamedTest2();
+    }
+}


### PR DESCRIPTION
Rewrite the wrong generic argument to the containing type for both the Serilog ForContext<T>() and the Microsoft ILogger<T> constructor shapes.

For the constructor shapes the field or property assigned from the parameter is retyped as well, so the type still compiles afterwards. ILogger<T> is covariant, so only members carrying the very same wrong type are rewritten - an ILogger<object> member is left alone.

ContextualLoggerWarning now carries the type argument node, the expected type and the parameter declaration. Its range is unchanged, so existing analyzer gold files are unaffected.