### PR TITLE
Add LoggerMessageAttribute support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ An extension for ReSharper and Rider IDE that highlights structured logging temp
 > [The highlighting is a built-in feature starting from R#/Rider 2021.2](https://github.com/olsh/resharper-structured-logging/issues/35#issuecomment-900883583),
 > but the extension still contains some useful analyzers that are not (yet) implemented by JetBrains team
 
-At the moment it supports Serilog, NLog, Microsoft.Extensions.Logging and ZLogger
+At the moment it supports Serilog, NLog, Microsoft.Extensions.Logging and ZLogger,
+including templates declared with `Microsoft.Extensions.Logging.LoggerMessageAttribute`
 
 ## Installation ReSharper
 

--- a/src/ReSharper.Structured.Logging/Analyzer/AnonymousTypeDestructureAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/AnonymousTypeDestructureAnalyzer.cs
@@ -45,7 +45,7 @@ namespace ReSharper.Structured.Logging.Analyzer
                 return;
             }
 
-            var templateText = templateArgument.TryGetTemplateText();
+            var templateText = templateArgument.Value.TryGetTemplateText();
             if (templateText == null)
             {
                 return;
@@ -69,7 +69,7 @@ namespace ReSharper.Structured.Logging.Analyzer
                         continue;
                     }
 
-                    var tokenInformation = templateArgument.GetTokenInformation(namedProperty);
+                    var tokenInformation = templateArgument.Value.GetTokenInformation(namedProperty);
                     consumer.AddHighlighting(new AnonymousObjectDestructuringWarning(tokenInformation));
                 }
             }

--- a/src/ReSharper.Structured.Logging/Analyzer/ComplexObjectDestructureAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/ComplexObjectDestructureAnalyzer.cs
@@ -70,7 +70,7 @@ namespace ReSharper.Structured.Logging.Analyzer
                 return;
             }
 
-            var templateText = templateArgument.TryGetTemplateText();
+            var templateText = templateArgument.Value.TryGetTemplateText();
             if (templateText == null)
             {
                 return;
@@ -105,7 +105,7 @@ namespace ReSharper.Structured.Logging.Analyzer
                     }
 
                     consumer.AddHighlighting(
-                        new ComplexObjectDestructuringWarning(templateArgument.GetTokenInformation(namedProperty)));
+                        new ComplexObjectDestructuringWarning(templateArgument.Value.GetTokenInformation(namedProperty)));
                 }
             }
         }

--- a/src/ReSharper.Structured.Logging/Analyzer/DuplicatePropertiesTemplateAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/DuplicatePropertiesTemplateAnalyzer.cs
@@ -12,8 +12,8 @@ using ReSharper.Structured.Logging.Serilog.Parsing;
 
 namespace ReSharper.Structured.Logging.Analyzer
 {
-    [ElementProblemAnalyzer(typeof(IInvocationExpression))]
-    public class DuplicatePropertiesTemplateAnalyzer : ElementProblemAnalyzer<IInvocationExpression>
+    [ElementProblemAnalyzer(typeof(IInvocationExpression), typeof(IAttribute))]
+    public class DuplicatePropertiesTemplateAnalyzer : ElementProblemAnalyzer<ICSharpArgumentsOwner>
     {
         private readonly MessageTemplateParser _messageTemplateParser;
 
@@ -26,12 +26,12 @@ namespace ReSharper.Structured.Logging.Analyzer
         }
 
         protected override void Run(
-            IInvocationExpression element,
+            ICSharpArgumentsOwner element,
             ElementProblemAnalyzerData data,
             IHighlightingConsumer consumer)
         {
-            var templateArgument = element.GetTemplateArgument(_templateParameterNameAttributeProvider.Value);
-            var templateText = templateArgument?.TryGetTemplateText();
+            var templateExpression = element.GetTemplateExpression(_templateParameterNameAttributeProvider.Value);
+            var templateText = templateExpression?.TryGetTemplateText();
             if (templateText == null)
             {
                 return;
@@ -49,7 +49,7 @@ namespace ReSharper.Structured.Logging.Analyzer
             {
                 foreach (var token in duplicates)
                 {
-                    consumer.AddHighlighting(new DuplicateTemplatePropertyWarning(templateArgument.GetTokenInformation(token)));
+                    consumer.AddHighlighting(new DuplicateTemplatePropertyWarning(templateExpression.GetTokenInformation(token)));
                 }
             }
         }

--- a/src/ReSharper.Structured.Logging/Analyzer/LogMessageIsSentenceAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/LogMessageIsSentenceAnalyzer.cs
@@ -12,8 +12,8 @@ using ReSharper.Structured.Logging.Highlighting;
 
 namespace ReSharper.Structured.Logging.Analyzer
 {
-    [ElementProblemAnalyzer(typeof(IInvocationExpression), HighlightingTypes = new[] { typeof(LogMessageIsSentenceWarning) })]
-    public class LogMessageIsSentenceAnalyzer : ElementProblemAnalyzer<IInvocationExpression>
+    [ElementProblemAnalyzer(typeof(IInvocationExpression), typeof(IAttribute), HighlightingTypes = new[] { typeof(LogMessageIsSentenceWarning) })]
+    public class LogMessageIsSentenceAnalyzer : ElementProblemAnalyzer<ICSharpArgumentsOwner>
     {
         private readonly Lazy<TemplateParameterNameAttributeProvider> _templateParameterNameAttributeProvider;
 
@@ -24,10 +24,10 @@ namespace ReSharper.Structured.Logging.Analyzer
             _templateParameterNameAttributeProvider = codeAnnotationsCache.GetLazyProvider<TemplateParameterNameAttributeProvider>();
         }
 
-        protected override void Run(IInvocationExpression element, ElementProblemAnalyzerData data, IHighlightingConsumer consumer)
+        protected override void Run(ICSharpArgumentsOwner element, ElementProblemAnalyzerData data, IHighlightingConsumer consumer)
         {
-            var templateArgument = element.GetTemplateArgument(_templateParameterNameAttributeProvider.Value);
-            var lastFragmentExpression = templateArgument?.TryCreateLastTemplateFragmentExpression();
+            var templateExpression = element.GetTemplateExpression(_templateParameterNameAttributeProvider.Value);
+            var lastFragmentExpression = templateExpression?.TryCreateLastTemplateFragmentExpression();
             if (lastFragmentExpression == null)
             {
                 return;

--- a/src/ReSharper.Structured.Logging/Analyzer/PositionalPropertiesUsageAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/PositionalPropertiesUsageAnalyzer.cs
@@ -11,8 +11,8 @@ using ReSharper.Structured.Logging.Serilog.Parsing;
 
 namespace ReSharper.Structured.Logging.Analyzer
 {
-    [ElementProblemAnalyzer(typeof(IInvocationExpression))]
-    public class PositionalPropertiesUsageAnalyzer : ElementProblemAnalyzer<IInvocationExpression>
+    [ElementProblemAnalyzer(typeof(IInvocationExpression), typeof(IAttribute))]
+    public class PositionalPropertiesUsageAnalyzer : ElementProblemAnalyzer<ICSharpArgumentsOwner>
     {
         private readonly MessageTemplateParser _messageTemplateParser;
 
@@ -25,12 +25,12 @@ namespace ReSharper.Structured.Logging.Analyzer
         }
 
         protected override void Run(
-            IInvocationExpression element,
+            ICSharpArgumentsOwner element,
             ElementProblemAnalyzerData data,
             IHighlightingConsumer consumer)
         {
-            var templateArgument = element.GetTemplateArgument(_templateParameterNameAttributeProvider.Value);
-            var templateText = templateArgument?.TryGetTemplateText();
+            var templateExpression = element.GetTemplateExpression(_templateParameterNameAttributeProvider.Value);
+            var templateText = templateExpression?.TryGetTemplateText();
             if (templateText == null)
             {
                 return;
@@ -44,7 +44,7 @@ namespace ReSharper.Structured.Logging.Analyzer
 
             foreach (var property in messageTemplate.PositionalProperties)
             {
-                consumer.AddHighlighting(new PositionalPropertyUsedWarning(templateArgument.GetTokenInformation(property)));
+                consumer.AddHighlighting(new PositionalPropertyUsedWarning(templateExpression.GetTokenInformation(property)));
             }
         }
     }

--- a/src/ReSharper.Structured.Logging/Analyzer/PropertiesNamingAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/PropertiesNamingAnalyzer.cs
@@ -17,8 +17,8 @@ using ReSharper.Structured.Logging.Settings;
 
 namespace ReSharper.Structured.Logging.Analyzer;
 
-[ElementProblemAnalyzer(typeof(IInvocationExpression))]
-public class PropertiesNamingAnalyzer : ElementProblemAnalyzer<IInvocationExpression>
+[ElementProblemAnalyzer(typeof(IInvocationExpression), typeof(IAttribute))]
+public class PropertiesNamingAnalyzer : ElementProblemAnalyzer<ICSharpArgumentsOwner>
 {
     private readonly MessageTemplateParser _messageTemplateParser;
 
@@ -31,7 +31,7 @@ public class PropertiesNamingAnalyzer : ElementProblemAnalyzer<IInvocationExpres
     }
 
     protected override void Run(
-        IInvocationExpression element,
+        ICSharpArgumentsOwner element,
         ElementProblemAnalyzerData data,
         IHighlightingConsumer consumer)
     {
@@ -43,17 +43,21 @@ public class PropertiesNamingAnalyzer : ElementProblemAnalyzer<IInvocationExpres
         var ignoredPropertiesRegex = string.IsNullOrWhiteSpace(ignoreRegexString) ? null : new Regex(ignoreRegexString);
 
         CheckPropertiesInTemplate(element, consumer, settingsStore, ignoredPropertiesRegex);
-        CheckPropertiesInContext(element, consumer, settingsStore, ignoredPropertiesRegex);
+
+        if (element is IInvocationExpression invocationExpression)
+        {
+            CheckPropertiesInContext(invocationExpression, consumer, settingsStore, ignoredPropertiesRegex);
+        }
     }
 
     private void CheckPropertiesInTemplate(
-        IInvocationExpression element,
+        ICSharpArgumentsOwner element,
         IHighlightingConsumer consumer,
         IContextBoundSettingsStore settingsStore,
         Regex ignoredPropertiesRegex)
     {
-        var templateArgument = element.GetTemplateArgument(_templateParameterNameAttributeProvider.Value);
-        var templateText = templateArgument?.TryGetTemplateText();
+        var templateExpression = element.GetTemplateExpression(_templateParameterNameAttributeProvider.Value);
+        var templateText = templateExpression?.TryGetTemplateText();
         if (templateText == null)
         {
             return;
@@ -79,7 +83,7 @@ public class PropertiesNamingAnalyzer : ElementProblemAnalyzer<IInvocationExpres
             }
 
             consumer.AddHighlighting(
-                new InconsistentLogPropertyNamingWarning(templateArgument.GetTokenInformation(property), property,
+                new InconsistentLogPropertyNamingWarning(templateExpression.GetTokenInformation(property), property,
                     suggestedName));
         }
     }

--- a/src/ReSharper.Structured.Logging/Caching/TemplateParameterNameAttributeProvider.cs
+++ b/src/ReSharper.Structured.Logging/Caching/TemplateParameterNameAttributeProvider.cs
@@ -39,6 +39,13 @@ public class TemplateParameterNameAttributeProvider(
             return "format";
         }
 
+        if (className == "Microsoft.Extensions.Logging.LoggerMessageAttribute")
+        {
+            // The template is either the `message` constructor parameter or the `Message` property.
+            // Every other member (EventId, EventName, Level, SkipEnabledCheck) holds no template.
+            return attributesOwner is IConstructor || attributesOwner.ShortName == "Message" ? "message" : null;
+        }
+
         return null;
     }
 

--- a/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
+++ b/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -26,41 +27,54 @@ namespace ReSharper.Structured.Logging.Extensions
         [CanBeNull]
         public static ICSharpArgument GetTemplateArgument(this IInvocationExpression invocationExpression, TemplateParameterNameAttributeProvider templateParameterNameAttributeProvider)
         {
-            if (!(invocationExpression.Reference.Resolve().DeclaredElement is ITypeMember typeMember))
-            {
-                return null;
-            }
+            var templateParameterName = invocationExpression.GetTemplateParameterName(templateParameterNameAttributeProvider);
 
-            var templateParameterName = templateParameterNameAttributeProvider.GetInfo(typeMember);
+            return string.IsNullOrEmpty(templateParameterName)
+                       ? null
+                       : invocationExpression.FindTemplateArgument(templateParameterName);
+        }
+
+        /// <summary>
+        /// Returns the message template expression of a logging call or of a logging attribute
+        /// such as [LoggerMessage(Message = "...")].
+        /// </summary>
+        [CanBeNull]
+        public static ICSharpExpression GetTemplateExpression(this ICSharpArgumentsOwner argumentsOwner, TemplateParameterNameAttributeProvider templateParameterNameAttributeProvider)
+        {
+            var templateParameterName = argumentsOwner.GetTemplateParameterName(templateParameterNameAttributeProvider);
             if (string.IsNullOrEmpty(templateParameterName))
             {
                 return null;
             }
 
-            foreach (var argument in invocationExpression.ArgumentList.Arguments)
+            var templateArgument = argumentsOwner.FindTemplateArgument(templateParameterName);
+            if (templateArgument != null)
             {
-                if (argument.MatchingParameter?.Element.ShortName == templateParameterName)
-                {
-                    return argument;
-                }
+                return templateArgument.Value;
+            }
+
+            // An attribute can also carry the template in a named property, e.g. [LoggerMessage(Message = "...")]
+            if (argumentsOwner is IAttribute attribute)
+            {
+                return attribute.FindTemplatePropertyAssignment(templateParameterName)?.Source;
             }
 
             return null;
         }
 
-        public static MessageTemplateTokenInformation GetTokenInformation(this ICSharpArgument argument, MessageTemplateToken token)
+        public static MessageTemplateTokenInformation GetTokenInformation(this ICSharpExpression templateExpression, MessageTemplateToken token)
         {
-            var (tokenTextRange, tokenArgument) = FindTokenTextRange(argument, token);
-            var tokenDocument = argument.GetDocumentRange().Document;
+            var (tokenTextRange, tokenArgument) = FindTokenTextRange(templateExpression, token);
+            var tokenDocument = templateExpression.GetDocumentRange().Document;
             var documentRange = new DocumentRange(tokenDocument, tokenTextRange);
 
             return new MessageTemplateTokenInformation(documentRange, tokenArgument);
         }
 
         // ReSharper disable once CognitiveComplexity
-        private static (TextRange, IStringLiteralAlterer) FindTokenTextRange(this ICSharpArgument argument, MessageTemplateToken token)
+        private static (TextRange, IStringLiteralAlterer) FindTokenTextRange(this ICSharpExpression templateExpression, MessageTemplateToken token)
         {
-            if (argument.Value is IAdditiveExpression additiveExpression && additiveExpression.ConstantValue.IsString())
+            if (templateExpression is IAdditiveExpression additiveExpression && additiveExpression.ConstantValue.IsString())
             {
                 var arguments = new LinkedList<ExpressionArgumentInfo>();
                 FlattenAdditiveExpression(additiveExpression, arguments);
@@ -95,19 +109,19 @@ namespace ReSharper.Structured.Logging.Extensions
                 }
             }
 
-            var startOffset = argument.GetDocumentRange().TextRange.StartOffset + token.StartIndex + 1;
-            if (argument.Expression.IsVerbatimString())
+            var startOffset = templateExpression.GetDocumentRange().TextRange.StartOffset + token.StartIndex + 1;
+            if (templateExpression.IsVerbatimString())
             {
                 startOffset++;
             }
 
             // ReSharper disable once AssignNullToNotNullAttribute
-            return (new TextRange(startOffset, startOffset + token.Length), StringLiteralAltererUtil.TryCreateStringLiteralByExpression(argument.Expression));
+            return (new TextRange(startOffset, startOffset + token.Length), StringLiteralAltererUtil.TryCreateStringLiteralByExpression(templateExpression));
         }
 
-        public static string TryGetTemplateText(this ICSharpArgument argument)
+        public static string TryGetTemplateText(this ICSharpExpression templateExpression)
         {
-            if (argument.Value is IAdditiveExpression additiveExpression && additiveExpression.ConstantValue.IsString())
+            if (templateExpression is IAdditiveExpression additiveExpression && additiveExpression.ConstantValue.IsString())
             {
                 var linkedList = new LinkedList<ExpressionArgumentInfo>();
                 FlattenAdditiveExpression(additiveExpression, linkedList);
@@ -115,13 +129,13 @@ namespace ReSharper.Structured.Logging.Extensions
                 return string.Join(string.Empty, linkedList.Select(l => l.Expression.GetExpressionText()));
             }
 
-            return argument.Value.GetExpressionText();
+            return templateExpression.GetExpressionText();
         }
 
         [CanBeNull]
-        public static IStringLiteralAlterer TryCreateLastTemplateFragmentExpression(this ICSharpArgument argument)
+        public static IStringLiteralAlterer TryCreateLastTemplateFragmentExpression(this ICSharpExpression templateExpression)
         {
-            if (argument.Value is IAdditiveExpression additiveExpression && additiveExpression.ConstantValue.IsString())
+            if (templateExpression is IAdditiveExpression additiveExpression && additiveExpression.ConstantValue.IsString())
             {
                 var argumentInfo = additiveExpression.Arguments.Last();
                 if (argumentInfo is ExpressionArgumentInfo expressionArgumentInfo)
@@ -132,7 +146,7 @@ namespace ReSharper.Structured.Logging.Extensions
                 return null;
             }
 
-            return argument.Value == null ? null : StringLiteralAltererUtil.TryCreateStringLiteralByExpression(argument.Value);
+            return templateExpression == null ? null : StringLiteralAltererUtil.TryCreateStringLiteralByExpression(templateExpression);
         }
 
         public static bool IsGenericMicrosoftExtensionsLogger([NotNull]this IDeclaredType declared)
@@ -226,6 +240,48 @@ namespace ReSharper.Structured.Logging.Extensions
             }
 
             return StringUtil.Unquote(expressionText);
+        }
+
+        [CanBeNull]
+        private static string GetTemplateParameterName(this ICSharpArgumentsOwner argumentsOwner, TemplateParameterNameAttributeProvider templateParameterNameAttributeProvider)
+        {
+            // An attribute usage resolves the invoked constructor through a dedicated reference
+            var declaredElement = argumentsOwner is IAttribute attribute
+                                      ? attribute.ConstructorReference?.Resolve().DeclaredElement
+                                      : argumentsOwner.Reference?.Resolve().DeclaredElement;
+
+            return declaredElement is ITypeMember typeMember
+                       ? templateParameterNameAttributeProvider.GetInfo(typeMember)
+                       : null;
+        }
+
+        [CanBeNull]
+        private static ICSharpArgument FindTemplateArgument(this ICSharpArgumentsOwner argumentsOwner, string templateParameterName)
+        {
+            foreach (var argument in argumentsOwner.Arguments)
+            {
+                if (argument.MatchingParameter?.Element.ShortName == templateParameterName)
+                {
+                    return argument;
+                }
+            }
+
+            return null;
+        }
+
+        [CanBeNull]
+        private static IPropertyAssignment FindTemplatePropertyAssignment(this IAttribute attribute, string templateParameterName)
+        {
+            foreach (var propertyAssignment in attribute.PropertyAssignments)
+            {
+                // The attribute property mirrors the constructor parameter, e.g. `message` and `Message`
+                if (string.Equals(propertyAssignment.PropertyNameIdentifier?.Name, templateParameterName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return propertyAssignment;
+                }
+            }
+
+            return null;
         }
 
         private static void FlattenAdditiveExpression(IAdditiveExpression additiveExpression, LinkedList<ExpressionArgumentInfo> list)

--- a/test/data/Analyzers/LoggerMessageAttribute/ConcatenatedMessage.cs
+++ b/test/data/Analyzers/LoggerMessageAttribute/ConcatenatedMessage.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Could not open " + "socket to {hostName}")]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}

--- a/test/data/Analyzers/LoggerMessageAttribute/ConcatenatedMessage.cs.gold
+++ b/test/data/Analyzers/LoggerMessageAttribute/ConcatenatedMessage.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Could not open " + "socket to |{hostName}|(0)")]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}
+
+---------------------------------------------------------
+(0): ReSharper Warning: Property name 'hostName' does not match naming rules. Suggested name is 'HostName'.

--- a/test/data/Analyzers/LoggerMessageAttribute/DuplicateProperties.cs
+++ b/test/data/Analyzers/LoggerMessageAttribute/DuplicateProperties.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "{Host} is not equal to {Host}")]
+        public static partial void HostMismatch(ILogger logger, string host, string otherHost);
+    }
+}

--- a/test/data/Analyzers/LoggerMessageAttribute/DuplicateProperties.cs.gold
+++ b/test/data/Analyzers/LoggerMessageAttribute/DuplicateProperties.cs.gold
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "|{Host}|(0) is not equal to |{Host}|(1)")]
+        public static partial void HostMismatch(ILogger logger, string host, string otherHost);
+    }
+}
+
+---------------------------------------------------------
+(0): ReSharper Warning: Duplicate properties in message template
+(1): ReSharper Warning: Duplicate properties in message template

--- a/test/data/Analyzers/LoggerMessageAttribute/MessageIsSentence.cs
+++ b/test/data/Analyzers/LoggerMessageAttribute/MessageIsSentence.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Could not open socket to {HostName}.")]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}

--- a/test/data/Analyzers/LoggerMessageAttribute/MessageIsSentence.cs.gold
+++ b/test/data/Analyzers/LoggerMessageAttribute/MessageIsSentence.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = |"Could not open socket to {HostName}."|(0))]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}
+
+---------------------------------------------------------
+(0): ReSharper Warning: Log event messages should be fragments, not sentences. Avoid a trailing period/full stop.

--- a/test/data/Analyzers/LoggerMessageAttribute/MethodTargetAttribute.cs
+++ b/test/data/Analyzers/LoggerMessageAttribute/MethodTargetAttribute.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [method: LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Could not open socket to {hostName}")]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}

--- a/test/data/Analyzers/LoggerMessageAttribute/MethodTargetAttribute.cs.gold
+++ b/test/data/Analyzers/LoggerMessageAttribute/MethodTargetAttribute.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [method: LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Could not open socket to |{hostName}|(0)")]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}
+
+---------------------------------------------------------
+(0): ReSharper Warning: Property name 'hostName' does not match naming rules. Suggested name is 'HostName'.

--- a/test/data/Analyzers/LoggerMessageAttribute/NamedMessageInvalidProperty.cs
+++ b/test/data/Analyzers/LoggerMessageAttribute/NamedMessageInvalidProperty.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Could not open socket to {hostName}")]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}

--- a/test/data/Analyzers/LoggerMessageAttribute/NamedMessageInvalidProperty.cs.gold
+++ b/test/data/Analyzers/LoggerMessageAttribute/NamedMessageInvalidProperty.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Could not open socket to |{hostName}|(0)")]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}
+
+---------------------------------------------------------
+(0): ReSharper Warning: Property name 'hostName' does not match naming rules. Suggested name is 'HostName'.

--- a/test/data/Analyzers/LoggerMessageAttribute/NonConstantMessage.cs
+++ b/test/data/Analyzers/LoggerMessageAttribute/NonConstantMessage.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        private const string Template = "Could not open socket to {hostName}";
+
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = Template)]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}

--- a/test/data/Analyzers/LoggerMessageAttribute/NonConstantMessage.cs.gold
+++ b/test/data/Analyzers/LoggerMessageAttribute/NonConstantMessage.cs.gold
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        private const string Template = "Could not open socket to {hostName}";
+
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = Template)]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}
+
+---------------------------------------------------------

--- a/test/data/Analyzers/LoggerMessageAttribute/OtherAttributePropertiesIgnored.cs
+++ b/test/data/Analyzers/LoggerMessageAttribute/OtherAttributePropertiesIgnored.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, EventName = "{eventName}", Level = LogLevel.Information, Message = "Could not open socket")]
+        public static partial void CouldNotOpenSocket(ILogger logger);
+    }
+}

--- a/test/data/Analyzers/LoggerMessageAttribute/OtherAttributePropertiesIgnored.cs.gold
+++ b/test/data/Analyzers/LoggerMessageAttribute/OtherAttributePropertiesIgnored.cs.gold
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, EventName = "{eventName}", Level = LogLevel.Information, Message = "Could not open socket")]
+        public static partial void CouldNotOpenSocket(ILogger logger);
+    }
+}
+
+---------------------------------------------------------

--- a/test/data/Analyzers/LoggerMessageAttribute/PositionalMessageInvalidProperty.cs
+++ b/test/data/Analyzers/LoggerMessageAttribute/PositionalMessageInvalidProperty.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(0, LogLevel.Information, "Could not open socket to {hostName}")]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}

--- a/test/data/Analyzers/LoggerMessageAttribute/PositionalMessageInvalidProperty.cs.gold
+++ b/test/data/Analyzers/LoggerMessageAttribute/PositionalMessageInvalidProperty.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(0, LogLevel.Information, "Could not open socket to |{hostName}|(0)")]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}
+
+---------------------------------------------------------
+(0): ReSharper Warning: Property name 'hostName' does not match naming rules. Suggested name is 'HostName'.

--- a/test/data/Analyzers/LoggerMessageAttribute/PositionalProperty.cs
+++ b/test/data/Analyzers/LoggerMessageAttribute/PositionalProperty.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Could not open socket to {0}")]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}

--- a/test/data/Analyzers/LoggerMessageAttribute/PositionalProperty.cs.gold
+++ b/test/data/Analyzers/LoggerMessageAttribute/PositionalProperty.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Could not open socket to |{0}|(0)")]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}
+
+---------------------------------------------------------
+(0): ReSharper Warning: Prefer named properties instead of positional ones

--- a/test/data/Analyzers/PropertiesNamingAnalyzerDotNet6/MicrosoftNamedMessageArgument.cs
+++ b/test/data/Analyzers/PropertiesNamingAnalyzerDotNet6/MicrosoftNamedMessageArgument.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    class A
+    {
+        public A(ILogger<A> log)
+        {
+            log.LogInformation(message: "{myProperty}", 1);
+        }
+    }
+}

--- a/test/data/Analyzers/PropertiesNamingAnalyzerDotNet6/MicrosoftNamedMessageArgument.cs.gold
+++ b/test/data/Analyzers/PropertiesNamingAnalyzerDotNet6/MicrosoftNamedMessageArgument.cs.gold
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    class A
+    {
+        public A(ILogger<A> log)
+        {
+            log.LogInformation(message: "|{myProperty}|(0)", 1);
+        }
+    }
+}
+
+---------------------------------------------------------
+(0): ReSharper Warning: Property name 'myProperty' does not match naming rules. Suggested name is 'MyProperty'.

--- a/test/data/QuickFixes/RemoveTrailingPeriodFix/TestLoggerMessageAttribute.cs
+++ b/test/data/QuickFixes/RemoveTrailingPeriodFix/TestLoggerMessageAttribute.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "{caret}Could not open socket.")]
+        public static partial void CouldNotOpenSocket(ILogger logger);
+    }
+}

--- a/test/data/QuickFixes/RemoveTrailingPeriodFix/TestLoggerMessageAttribute.cs.gold
+++ b/test/data/QuickFixes/RemoveTrailingPeriodFix/TestLoggerMessageAttribute.cs.gold
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "{caret}Could not open socket")]
+        public static partial void CouldNotOpenSocket(ILogger logger);
+    }
+}

--- a/test/data/QuickFixes/RenameLogPropertyFix/TestLoggerMessageAttribute.cs
+++ b/test/data/QuickFixes/RenameLogPropertyFix/TestLoggerMessageAttribute.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Could not open socket to {host{caret}Name}")]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}

--- a/test/data/QuickFixes/RenameLogPropertyFix/TestLoggerMessageAttribute.cs.gold
+++ b/test/data/QuickFixes/RenameLogPropertyFix/TestLoggerMessageAttribute.cs.gold
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Could not open socket to {Host{caret}Name}")]
+        public static partial void CouldNotOpenSocket(ILogger logger, string hostName);
+    }
+}

--- a/test/data/QuickFixes/RenameLogPropertyFix/TestLoggerMessageAttributeConstructorArgument.cs
+++ b/test/data/QuickFixes/RenameLogPropertyFix/TestLoggerMessageAttributeConstructorArgument.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(0, LogLevel.Information, "Retrying {att{caret}empt}")]
+        public static partial void Retry(ILogger logger, int attempt);
+    }
+}

--- a/test/data/QuickFixes/RenameLogPropertyFix/TestLoggerMessageAttributeConstructorArgument.cs.gold
+++ b/test/data/QuickFixes/RenameLogPropertyFix/TestLoggerMessageAttributeConstructorArgument.cs.gold
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(0, LogLevel.Information, "Retrying {Att{caret}empt}")]
+        public static partial void Retry(ILogger logger, int attempt);
+    }
+}

--- a/test/data/QuickFixes/RenameLogPropertyFix/TestMicrosoftNamedMessageArgument.cs
+++ b/test/data/QuickFixes/RenameLogPropertyFix/TestMicrosoftNamedMessageArgument.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    class A
+    {
+        public A(ILogger<A> log)
+        {
+            log.LogInformation(message: "Test {my{caret}Property} prop", 1);
+        }
+    }
+}

--- a/test/data/QuickFixes/RenameLogPropertyFix/TestMicrosoftNamedMessageArgument.cs.gold
+++ b/test/data/QuickFixes/RenameLogPropertyFix/TestMicrosoftNamedMessageArgument.cs.gold
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    class A
+    {
+        public A(ILogger<A> log)
+        {
+            log.LogInformation(message: "Test {My{caret}Property} prop", 1);
+        }
+    }
+}

--- a/test/src/Analyzer/LoggerMessageAttributeAnalyzerTests.cs
+++ b/test/src/Analyzer/LoggerMessageAttributeAnalyzerTests.cs
@@ -1,0 +1,30 @@
+﻿using JetBrains.ReSharper.TestFramework;
+
+using NUnit.Framework;
+
+namespace ReSharper.Structured.Logging.Tests.Analyzer
+{
+    [TestNet60]
+    public class LoggerMessageAttributeAnalyzerTests : MessageTemplateAnalyzerTestBase
+    {
+        protected override string SubPath => "LoggerMessageAttribute";
+
+        [Test] public void TestNamedMessageInvalidProperty() => DoNamedTest2();
+
+        [Test] public void TestPositionalMessageInvalidProperty() => DoNamedTest2();
+
+        [Test] public void TestDuplicateProperties() => DoNamedTest2();
+
+        [Test] public void TestPositionalProperty() => DoNamedTest2();
+
+        [Test] public void TestMessageIsSentence() => DoNamedTest2();
+
+        [Test] public void TestOtherAttributePropertiesIgnored() => DoNamedTest2();
+
+        [Test] public void TestConcatenatedMessage() => DoNamedTest2();
+
+        [Test] public void TestNonConstantMessage() => DoNamedTest2();
+
+        [Test] public void TestMethodTargetAttribute() => DoNamedTest2();
+    }
+}

--- a/test/src/Analyzer/PropertiesNamingAnalyzerDotNet6Tests.cs
+++ b/test/src/Analyzer/PropertiesNamingAnalyzerDotNet6Tests.cs
@@ -15,5 +15,7 @@ namespace ReSharper.Structured.Logging.Tests.Analyzer
         protected override string SubPath => "PropertiesNamingAnalyzerDotNet6";
 
         [Test] public void TestZLoggerInvalidNamedProperty() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftNamedMessageArgument() => DoNamedTest2();
     }
 }

--- a/test/src/QuickFixes/RemoveTrailingPeriodFixDotNet6Tests.cs
+++ b/test/src/QuickFixes/RemoveTrailingPeriodFixDotNet6Tests.cs
@@ -15,5 +15,8 @@ namespace ReSharper.Structured.Logging.Tests.QuickFixes
 
         [Test]
         public void TestMicrosoftNamedMessageArgument() => DoNamedTest();
+
+        [Test]
+        public void TestLoggerMessageAttribute() => DoNamedTest();
     }
 }

--- a/test/src/QuickFixes/RenameLogPropertyFixDotNet6Tests.cs
+++ b/test/src/QuickFixes/RenameLogPropertyFixDotNet6Tests.cs
@@ -1,0 +1,27 @@
+﻿using JetBrains.ReSharper.FeaturesTestFramework.Intentions;
+using JetBrains.ReSharper.TestFramework;
+
+using NUnit.Framework;
+
+using ReSharper.Structured.Logging.QuickFixes;
+using ReSharper.Structured.Logging.Tests.Constants;
+
+namespace ReSharper.Structured.Logging.Tests.QuickFixes
+{
+    [TestFixture]
+    [TestNet60]
+    [TestPackages(NugetPackages.MicrosoftLoggingPackage)]
+    public class RenameLogPropertyFixDotNet6Tests : CSharpQuickFixTestBase<RenameLogPropertyFix>
+    {
+        protected override string RelativeTestDataPath => @"QuickFixes\RenameLogPropertyFix";
+
+        [Test]
+        public void TestLoggerMessageAttribute() => DoNamedTest();
+
+        [Test]
+        public void TestLoggerMessageAttributeConstructorArgument() => DoNamedTest();
+
+        [Test]
+        public void TestMicrosoftNamedMessageArgument() => DoNamedTest();
+    }
+}


### PR DESCRIPTION
Closes #81

Message templates declared with `Microsoft.Extensions.Logging.LoggerMessageAttribute` are now analyzed, both when the template is the `message` constructor argument and when it is the `Message` property:

```csharp
public static partial class Log
{
    // Property name 'hostName' does not match naming rules. Suggested name is 'HostName'.
    [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Could not open socket to {hostName}")]
    public static partial void CouldNotOpenSocket(ILogger logger, string hostName);

    // Prefer named properties instead of positional ones
    [LoggerMessage(1, LogLevel.Warning, "Retrying {0}")]
    public static partial void Retry(ILogger logger, int attempt);
}
```

## Behavior change

Four template-only analyzers now run on attributes as well as invocations, along with their existing quick fixes:

| Analyzer | Quick fix |
| --- | --- |
| `PropertiesNamingAnalyzer` | Rename property |
| `DuplicatePropertiesTemplateAnalyzer` | – |
| `PositionalPropertiesUsageAnalyzer` | – |
| `LogMessageIsSentenceAnalyzer` | Remove period |

The remaining analyzers stay invocation-only, deliberately: `ComplexObjectDestructureAnalyzer`, `AnonymousTypeDestructureAnalyzer` and `CorrectExceptionPassingAnalyzer` map template holes to value arguments, which an attribute does not have, and `CompileTimeConstantTemplateAnalyzer` is redundant because C# already requires attribute arguments to be constants.

`LoggerMessage.Define`/`DefineScope` (#64) is not part of this change.

## Implementation

`IAttribute` implements `ICSharpArgumentsOwner`, the same interface as `IInvocationExpression`, so the four analyzers are registered as `[ElementProblemAnalyzer(typeof(IInvocationExpression), typeof(IAttribute))]` over `ElementProblemAnalyzer<ICSharpArgumentsOwner>` — the pattern `ContextualLoggerConstructorAnalyzer` already uses for constructor declarations.

An attribute property assignment is an `IPropertyAssignment`, not an `ICSharpArgument`, so the pipeline's shared currency moved from the argument down to the template `ICSharpExpression`. `PsiExtensions.GetTemplateExpression` scans `Arguments` by `MatchingParameter` and falls back to `IAttribute.PropertyAssignments`; `GetTemplateArgument` remains for the analyzers that need the argument's `IndexOf()`. All library knowledge stays in `TemplateParameterNameAttributeProvider`, which gained a single `LoggerMessageAttribute` branch that recognizes constructors and the `Message` property only, so `EventId`/`Level`/`EventName`/`SkipEnabledCheck` are never mistaken for a template.

## Incidental fix

Token ranges were computed from the argument's document range, so a named argument shifted every highlight by the length of the argument name:

```csharp
logger.LogInformation(message: "{myProperty}");  // highlight was 9 characters off
```

`RenameLogPropertyFix` then threw `ArgumentOutOfRangeException` on such a call. Basing the offset on the expression fixes both. Verified by temporarily restoring the old base and watching the two new regression tests fail (`MicrosoftNamedMessageArgument` in the analyzer and rename-fix .NET 6 fixtures).

## Validation

`build.cmd Test` — 86/86 passing (76 before). New coverage: the `Message` property form, the positional constructor form, duplicate properties, positional properties, trailing period, `[method: LoggerMessage(...)]`, concatenated templates, a `const`-field message (ignored, no crash), a negative case proving `EventName` is not treated as a template, and both quick fixes rewriting the literal inside the attribute.

No new highlighting types, so no `rules/*.md` or severity registration changes. `Microsoft.Extensions.Logging/6.0.0` already brings `Microsoft.Extensions.Logging.Abstractions`, so `NugetPackages.cs` is unchanged.
