### PR TITLE
Automate publishing to JetBrains Marketplace

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,16 @@ on:
     branches:
       - master
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the packages to JetBrains Marketplace and create the GitHub release
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # A release must never be cancelled by a push that lands while it is publishing
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 permissions:
   contents: read
@@ -24,6 +30,9 @@ jobs:
   build:
     name: Build and test
     runs-on: windows-2025
+
+    outputs:
+      version: ${{ steps.version.outputs.value }}
 
     steps:
       - name: Check out repository
@@ -90,3 +99,51 @@ jobs:
           name: rider-package-${{ env.EXTENSION_VERSION }}
           path: rider-structured-logging-${{ env.EXTENSION_VERSION }}.zip
           if-no-files-found: error
+
+      # The pack targets export EXTENSION_VERSION into the job environment, which the release job
+      # cannot see, so hand it over as a job output instead
+      - name: Expose extension version
+        id: version
+        run: echo "value=$env:EXTENSION_VERSION" >> $env:GITHUB_OUTPUT
+
+      - name: Publish ReSharper plugin
+        if: inputs.publish
+        env:
+          MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
+        run: .\build.cmd PublishReSharperPlugin --configuration Release
+
+      - name: Publish Rider plugin
+        if: inputs.publish
+        env:
+          MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
+        run: .\build.cmd PublishRiderPlugin --configuration Release --is-rider-host
+
+  release:
+    name: Create GitHub release
+    needs: build
+    if: inputs.publish
+    runs-on: ubuntu-latest
+
+    # Scoped to this job so that ordinary build and pull request runs stay read-only
+    permissions:
+      contents: write
+
+    steps:
+      - name: Tag the commit and publish release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          if [ -z "$VERSION" ]; then
+            echo "::error::The build job did not report an extension version"
+            exit 1
+          fi
+
+          # EAP builds carry a prerelease suffix, for example 2025.1.0.373-eap02
+          case "$VERSION" in
+            *-*) prerelease=--prerelease ;;
+            *) prerelease= ;;
+          esac
+
+          gh release create "$VERSION" --target "$GITHUB_SHA" --title "$VERSION" --generate-notes $prerelease

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -28,6 +28,8 @@
         "Compile",
         "Pack",
         "PackRiderPlugin",
+        "PublishReSharperPlugin",
+        "PublishRiderPlugin",
         "RunIde",
         "Sonar",
         "SonarBegin",
@@ -110,6 +112,10 @@
         },
         "IsRiderHost": {
           "type": "boolean"
+        },
+        "MarketplaceToken": {
+          "type": "string",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
         "RunIdeSolution": {
           "type": "string"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,14 @@ Run commands from the repository root:
 
 The build requires a compatible .NET SDK; Rider packaging also requires a JDK 17 or newer to run Gradle. The JDK that the Rider build itself compiles against is derived from the target Rider version and provisioned automatically by the Foojay toolchain resolver configured in `settings.gradle`, so it does not need to be installed by hand. Generated output appears in `bin/`, `gradle-build/`, and repository-root package files and must not be committed.
 
+## Releasing
+
+Releases are published from the `Build` workflow, not from a tag. Run it manually with the `publish` input enabled (`gh workflow run build.yml --ref master -f publish=true`) and it packs both plugins, pushes the ReSharper `.nupkg` and the Rider `.zip` to JetBrains Marketplace, then creates the git tag and GitHub release. Publishing needs the `JETBRAINS_MARKETPLACE_TOKEN` repository secret, a permanent token from <https://plugins.jetbrains.com/author/me/tokens>.
+
+The published version and the tag are `<SdkVersion>.<workflow run number>`, where `SdkVersion` comes from `Directory.Build.props`. Marketplace rejects a version it already has, so a failed publish must be re-dispatched rather than re-run, and Marketplace moderation means a successful run only says the update was uploaded. An EAP `SdkVersion` suffix routes the Rider plugin to the `eap` channel and marks the GitHub release as a prerelease.
+
+The corresponding NUKE targets are `PublishReSharperPlugin` and `PublishRiderPlugin --is-rider-host`; both read the token from the `MARKETPLACE_TOKEN` environment variable and refuse to run without it.
+
 ## Development References
 
 When implementing features or editing ReSharper/Rider plugin code, consult the [ReSharper Platform SDK documentation](https://www.jetbrains.com/help/resharper/sdk/welcome.html) for supported APIs, extension points, and platform guidance.

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,11 @@ intellijPlatform {
     pluginConfiguration {
         name = rootProject.name
     }
+
+    publishing {
+        token    = providers.environmentVariable('PUBLISH_TOKEN')
+        channels = [PluginChannel]
+    }
 }
 
 prepareSandbox {

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
@@ -60,6 +62,8 @@ class Build : NukeBuild
 
     [Parameter] [Secret] readonly string SonarToken;
 
+    [Parameter] [Secret] readonly string MarketplaceToken;
+
     [Parameter] readonly AbsolutePath RunIdeSolution;
 
     [LocalPath("./gradlew.bat")] readonly Tool Gradle;
@@ -70,6 +74,8 @@ class Build : NukeBuild
     readonly Tool DotNetCleanup;
 
     string RiderPackagePath => RootDirectory / $"rider-structured-logging-{ExtensionVersion}.zip";
+
+    string ReSharperPackagePath => RootDirectory / $"{ProjectName}.{ExtensionVersion}.nupkg";
 
     // JetBrains is not very consistent in versioning
     // https://github.com/olsh/resharper-structured-logging/issues/35#issuecomment-892764206
@@ -86,6 +92,9 @@ class Build : NukeBuild
             return productVersion;
         }
     }
+
+    // EAP builds must not reach the stable channel of the Marketplace
+    string PluginChannel => string.IsNullOrEmpty(SdkVersionSuffix) ? "default" : "eap";
 
     string ProjectName => IsRiderHost
         ? "ReSharper.Structured.Logging.Rider"
@@ -181,6 +190,45 @@ class Build : NukeBuild
             PublishExtensionVersion();
         });
 
+    Target PublishReSharperPlugin => _ => _
+        .DependsOn(Pack)
+        .Requires(() => !IsRiderHost)
+        .Requires(() => MarketplaceToken)
+        .Executes(() =>
+        {
+            NuGetPush(s => s
+                .SetTargetPath(ReSharperPackagePath)
+                .SetSource("https://plugins.jetbrains.com/")
+                .SetApiKey(MarketplaceToken));
+        });
+
+    Target PublishRiderPlugin => _ => _
+        .DependsOn(PackRiderPlugin)
+        .Requires(() => IsRiderHost)
+        .Requires(() => MarketplaceToken)
+        .Executes(() =>
+        {
+            // NUKE logs tool arguments, so the token travels through the environment instead
+            // Seeding from Variables is required because this replaces the child process environment
+            var environmentVariables = new Dictionary<string, string>(Variables, StringComparer.OrdinalIgnoreCase)
+            {
+                ["PUBLISH_TOKEN"] = MarketplaceToken,
+            };
+
+            Gradle(
+                $"publishPlugin -PPluginVersion={ExtensionVersion} -PProductVersion={RiderProductVersion} -PDotNetOutputDirectory={OutputDirectory} -PDotNetProjectName={ProjectName} -PPluginChannel={PluginChannel}",
+                environmentVariables: environmentVariables,
+                logger:
+                (_, s) =>
+                {
+                    // Gradle writes warnings to stderr
+                    // By default logger will write stderr as errors
+                    // Keep Gradle warnings from being reported as CI build errors
+                    // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
+                    Serilog.Log.Debug(s);
+                });
+        });
+
     Target RunIde => _ => _
         .DependsOn(Compile)
         .Requires(() => IsRiderHost)
@@ -252,10 +300,11 @@ class Build : NukeBuild
             environmentFile.AppendAllLines(new[] { $"EXTENSION_VERSION={ExtensionVersion}" });
         }
 
-        // Both pack targets call this, but the ReSharper one always runs first and the version is
-        // the same, so a single summary entry is enough
+        // Both pack targets call this, and a publish run packs a second time, but the version is
+        // the same. The variable exported above is visible to every later step of the same job, so
+        // its absence means this is the first pack and the only one that should report the version
         var summaryFile = GitHubActions.StepSummaryFile;
-        if (!IsRiderHost && summaryFile != null)
+        if (!IsRiderHost && summaryFile != null && GetVariable("EXTENSION_VERSION") == null)
         {
             summaryFile.AppendAllLines(new[] { $"### Version `{ExtensionVersion}`" });
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,8 @@
 
 PluginVersion=_PLACEHOLDER_
 ProductVersion=_PLACEHOLDER_
+# Marketplace release channel; 'default' is the stable one
+PluginChannel=default
 DotNetOutputDirectory=./src/ReSharper.Structured.Logging/bin/ReSharper.Structured.Logging.Rider/Debug
 DotNetProjectName=ReSharper.Structured.Logging.Rider
 


### PR DESCRIPTION
Releases are manual today: the Build workflow uploads the ReSharper `.nupkg` and the Rider `.zip` as Actions artifacts only, and shipping a version means downloading both, uploading them to plugins.jetbrains.com by hand, then tagging and writing the GitHub release.

This makes a release one dispatch of the Build workflow with `publish` checked.

## What changed

**`build/Build.cs`**
- `PublishReSharperPlugin` — depends on `Pack`, then `NuGetPush` to `https://plugins.jetbrains.com/` with the already-pinned `NuGet.CommandLine`. The feed is NuGet v2, so `nuget.exe` appends `api/v2/package` itself.
- `PublishRiderPlugin` — depends on `PackRiderPlugin`, then Gradle `publishPlugin`. The token goes into the Gradle process environment as `PUBLISH_TOKEN` rather than onto the command line, because NUKE logs tool arguments.
- New `MarketplaceToken` secret parameter (reads `MARKETPLACE_TOKEN`, same convention as `SonarToken`), `ReSharperPackagePath`, and `PluginChannel`, which routes EAP SDK versions to the Marketplace `eap` channel instead of stable.
- The `### Version` job-summary line is now written once per job, since a publish run packs a second time.

**`build.gradle` / `gradle.properties`** — the `publishPlugin` task was present but unconfigured; it now takes its token from `PUBLISH_TOKEN` and its channel from the new `PluginChannel` property.

**`.github/workflows/build.yml`** — `workflow_dispatch` gains a `publish` boolean; two publish steps gated on it; a new `release` job that tags the commit and creates the release, marking EAP versions as prereleases. `contents: write` is scoped to that job so ordinary build and PR runs stay read-only, and `cancel-in-progress` now excludes dispatch runs so a push cannot kill a release mid-publish.

**`AGENTS.md`** — a Releasing section. **`.nuke/build.schema.json`** — regenerated.

## Why not a tag-triggered release workflow

`ExtensionVersion` is `<SdkVersion>.<github.run_number>` and the existing tags encode exactly that (`2025.1.0.373`). `run_number` is per workflow file, so a new `release.yml` would restart at 1 and publish `2026.2.1.1` for a tag named `2026.2.1.21`. Keeping publishing in the Build workflow preserves one monotonic counter.

## Validation

- `build.cmd Test`, `build.cmd Pack`, `build.cmd PackRiderPlugin --is-rider-host` all still succeed, so the new Gradle config does not disturb normal builds.
- Both publish targets refuse to run without a token — every target reports `NotRun`, no network call.
- `gradlew publishPlugin --dry-run` resolves the full task graph with the new `publishing` block.
- Workflow YAML parses; the release job's shell passes `bash -n` and selects `--prerelease` only for suffixed versions.

The actual upload is not exercised locally. Signing is deliberately out of scope — `publishPlugin` falls back to `buildPlugin`'s unsigned archive when signing is not configured, matching the existing unsigned releases.

Requires the `JETBRAINS_MARKETPLACE_TOKEN` repository secret, which is set.
