### PR TITLE
Harden the release workflow: concurrency and permission scoping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: true
@@ -31,6 +28,9 @@ jobs:
   build:
     name: Build and test
     runs-on: windows-2025
+
+    permissions:
+      contents: read
 
     outputs:
       version: ${{ steps.version.outputs.value }}
@@ -125,7 +125,6 @@ jobs:
     if: inputs.publish
     runs-on: ubuntu-latest
 
-    # Scoped to this job so that ordinary build and pull request runs stay read-only
     permissions:
       contents: write
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,10 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  # A release must never be cancelled by a push that lands while it is publishing
-  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+  # A dispatched release gets a group to itself, keyed on the run, so that a push landing while it
+  # publishes cannot cancel it half way through. Push and pull request runs keep superseding theirs
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
Two follow-up corrections to #160, both in `.github/workflows/build.yml`.

## 1. A dispatched release gets its own concurrency group

`cancel-in-progress` is a property of the run that is *starting*, not of the runs already in the group. Setting it to `false` for `workflow_dispatch` only stopped a release from cancelling other runs; a later push to `master` still arrives with `cancel-in-progress: true` and cancels the in-flight release, because both share the group `Build-refs/heads/master`.

That is exactly the case the guard was meant to cover, and it is the worst one: a cancellation between the ReSharper `nuget push` and the Rider `publishPlugin` leaves the version half published, and Marketplace will not accept that version number again.

Keying a dispatched release on `github.run_id` puts it in a group nothing else can join, so it neither cancels nor is cancelled. Push and pull request runs are unchanged and keep superseding their own predecessors.

## 2. Permissions are scoped per job

#160 failed the SonarCloud quality gate on `new_security_rating` (C, threshold A), from `githubactions:S8264` — *Read permissions should be defined at the job level* — on the workflow-level `contents: read`.

The rule did not fire before #160 because the workflow had a single job. Adding the `release` job made the workflow-level default something a second job inherits whether or not it needs it, which is the over-broad grant the rule is about.

The workflow-level block is gone; `build` declares `contents: read` and `release` keeps `contents: write`. Effective permissions are unchanged for both jobs.
