### PR TITLE
Add an option to dim logging statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ Look for `Structured Logging` in Settings -> Plugins -> Browse repositories.
 * [Inconsistent log property naming in context](rules/InconsistentContextLogPropertyNaming.md)
 * [Log event messages should be fragments, not sentences](rules/LogMessageIsSentenceProblem.md)
 
+## Dimming Logging Statements
+
+Logging statements can be greyed out, the way unreachable code is rendered, so that they stand out less than the
+surrounding code. The option is off by default; enable `Dim logging statements` in
+Settings -> Environment -> Structured Logging.
+
+Only a statement that consists of nothing but a logging call is dimmed, so a logging call feeding a larger expression
+keeps its usual colors. Analysis squiggles stay visible on dimmed statements.
+
 ## Turning Off Analyzers
 
 Individual analyzers can be disabled as needed either through code comments or by adding a line to a project's

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -158,6 +158,9 @@ class Build : NukeBuild
         {
             NuGetPack(s => s
                 .SetTargetPath(BuildProjectDirectory / "ReSharper.Structured.Logging.nuspec")
+                // A ReSharper extension ships its assembly in dotFiles rather than lib, which package
+                // analysis reports as NU5100
+                .SetNoPackageAnalysis(true)
                 .SetVersion(ExtensionVersion)
                 .SetBasePath(OutputDirectory)
                 .AddProperty("project", ProjectName)

--- a/build/ReSharper.Structured.Logging.nuspec
+++ b/build/ReSharper.Structured.Logging.nuspec
@@ -9,7 +9,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/olsh/resharper-structured-logging</projectUrl>
-    <description>Analyzers for structured logging message templates in .NET. Supports Serilog, NLog, Microsoft.Extensions.Logging and ZLogger, including templates declared with LoggerMessageAttribute and LoggerMessage.Define/DefineScope. Reports objects that are not destructured, contextual logger mismatches, exceptions passed as template arguments, duplicate template properties, templates that are not compile-time constants, positional properties used instead of named ones, inconsistent property naming, and log messages written as sentences.</description>
+    <description>Analyzers for structured logging message templates in .NET. Supports Serilog, NLog, Microsoft.Extensions.Logging and ZLogger, including templates declared with LoggerMessageAttribute and LoggerMessage.Define/DefineScope. Reports objects that are not destructured, contextual logger mismatches, exceptions passed as template arguments, duplicate template properties, templates that are not compile-time constants, positional properties used instead of named ones, inconsistent property naming, and log messages written as sentences. Logging statements can optionally be dimmed so that they stand out less than the surrounding code.</description>
     <releaseNotes>https://github.com/olsh/resharper-structured-logging/releases</releaseNotes>
     <tags>resharper rider serilog nlog zlogger microsoft-extensions-logging templates logging structuredlogging analyzers</tags>
     <dependencies>

--- a/src/ReSharper.Structured.Logging/Analyzer/DimLoggingStatementAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/DimLoggingStatementAnalyzer.cs
@@ -1,0 +1,66 @@
+using System;
+
+using JetBrains.ReSharper.Feature.Services.Daemon;
+using JetBrains.ReSharper.Psi.CodeAnnotations;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Tree;
+
+using ReSharper.Structured.Logging.Caching;
+using ReSharper.Structured.Logging.Extensions;
+using ReSharper.Structured.Logging.Highlighting;
+using ReSharper.Structured.Logging.Settings;
+
+namespace ReSharper.Structured.Logging.Analyzer
+{
+    [ElementProblemAnalyzer(typeof(IInvocationExpression), HighlightingTypes = new[] { typeof(DimmedLoggingStatementHighlighting) })]
+    public class DimLoggingStatementAnalyzer : ElementProblemAnalyzer<IInvocationExpression>
+    {
+        private readonly Lazy<TemplateParameterNameAttributeProvider> _templateParameterNameAttributeProvider;
+
+        public DimLoggingStatementAnalyzer(CodeAnnotationsCache codeAnnotationsCache)
+        {
+            _templateParameterNameAttributeProvider = codeAnnotationsCache.GetLazyProvider<TemplateParameterNameAttributeProvider>();
+        }
+
+        protected override void Run(
+            IInvocationExpression element,
+            ElementProblemAnalyzerData data,
+            IHighlightingConsumer consumer)
+        {
+            if (!data.SettingsStore.GetValue(StructuredLoggingSettingsAccessor.DimLoggingStatements))
+            {
+                return;
+            }
+
+            if (element.GetTemplateParameterName(_templateParameterNameAttributeProvider.Value) == null)
+            {
+                return;
+            }
+
+            var statement = GetDimmableStatement(element);
+            if (statement == null)
+            {
+                return;
+            }
+
+            consumer.AddHighlighting(new DimmedLoggingStatementHighlighting(statement.GetDocumentRange()));
+        }
+
+        /// <summary>
+        /// Only a statement that is nothing but the logging call is dimmed, so that a logging call feeding a
+        /// larger expression, such as <c>var written = Log.Write(...) &amp;&amp; Save()</c>, keeps its colors.
+        /// </summary>
+        private static IExpressionStatement GetDimmableStatement(IInvocationExpression invocationExpression)
+        {
+            var statement = ExpressionStatementNavigator.GetByExpression(invocationExpression);
+            if (statement != null)
+            {
+                return statement;
+            }
+
+            var awaitExpression = AwaitExpressionNavigator.GetByTask(invocationExpression);
+
+            return awaitExpression == null ? null : ExpressionStatementNavigator.GetByExpression(awaitExpression);
+        }
+    }
+}

--- a/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
+++ b/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
@@ -73,41 +73,14 @@ namespace ReSharper.Structured.Logging.Extensions
             return new MessageTemplateTokenInformation(documentRange, tokenArgument);
         }
 
-        // ReSharper disable once CognitiveComplexity
         private static (TextRange, IStringLiteralAlterer) FindTokenTextRange(this ICSharpExpression templateExpression, MessageTemplateToken token)
         {
             if (templateExpression is IAdditiveExpression additiveExpression && additiveExpression.ConstantValue.IsString())
             {
-                var arguments = new LinkedList<ExpressionArgumentInfo>();
-                FlattenAdditiveExpression(additiveExpression, arguments);
-
-                var globalOffset = 0;
-                foreach (var additiveArgument in arguments)
+                var concatenatedRange = FindTokenTextRangeInConcatenation(additiveExpression, token);
+                if (concatenatedRange.HasValue)
                 {
-                    var range = additiveArgument.GetDocumentRange();
-                    var start = range.StartOffset.Offset;
-                    var end = range.EndOffset.Offset;
-
-                    // Usually there are two quotes in the string expression
-                    // But if it's a verbatim string, we should count @ symbol as well
-                    var isVerbatimString = additiveArgument.Expression.IsVerbatimString();
-                    var nonTemplateTokenCount = isVerbatimString ? 3 : 2;
-
-                    // The token index is zero-based so we need to subtract 1
-                    if (token.StartIndex < end - start - 1 - nonTemplateTokenCount + globalOffset)
-                    {
-                        var tokenStartIndex = start + token.StartIndex - globalOffset + 1;
-                        if (isVerbatimString)
-                        {
-                            tokenStartIndex++;
-                        }
-
-                        var tokenEndIndex = tokenStartIndex + token.Length;
-
-                        return (new TextRange(tokenStartIndex, end > tokenEndIndex ? tokenEndIndex : end), StringLiteralAltererUtil.TryCreateStringLiteralByExpression(additiveArgument.Expression));
-                    }
-
-                    globalOffset += end - start - nonTemplateTokenCount;
+                    return concatenatedRange.Value;
                 }
             }
 
@@ -119,6 +92,48 @@ namespace ReSharper.Structured.Logging.Extensions
 
             // ReSharper disable once AssignNullToNotNullAttribute
             return (new TextRange(startOffset, startOffset + token.Length), StringLiteralAltererUtil.TryCreateStringLiteralByExpression(templateExpression));
+        }
+
+        /// <summary>
+        /// Walks the fragments of a concatenated template, tracking how many characters of the template each
+        /// fragment contributes, and returns the range of the fragment the token falls into, or <c>null</c>
+        /// when the token lies past the end of the concatenation.
+        /// </summary>
+        private static (TextRange, IStringLiteralAlterer)? FindTokenTextRangeInConcatenation(IAdditiveExpression additiveExpression, MessageTemplateToken token)
+        {
+            var arguments = new LinkedList<ExpressionArgumentInfo>();
+            FlattenAdditiveExpression(additiveExpression, arguments);
+
+            var globalOffset = 0;
+            foreach (var additiveArgument in arguments)
+            {
+                var range = additiveArgument.GetDocumentRange();
+                var start = range.StartOffset.Offset;
+                var end = range.EndOffset.Offset;
+
+                // Usually there are two quotes in the string expression
+                // But if it's a verbatim string, we should count @ symbol as well
+                var isVerbatimString = additiveArgument.Expression.IsVerbatimString();
+                var nonTemplateTokenCount = isVerbatimString ? 3 : 2;
+
+                // The token index is zero-based so we need to subtract 1
+                if (token.StartIndex < end - start - 1 - nonTemplateTokenCount + globalOffset)
+                {
+                    var tokenStartIndex = start + token.StartIndex - globalOffset + 1;
+                    if (isVerbatimString)
+                    {
+                        tokenStartIndex++;
+                    }
+
+                    var tokenEndIndex = tokenStartIndex + token.Length;
+
+                    return (new TextRange(tokenStartIndex, end > tokenEndIndex ? tokenEndIndex : end), StringLiteralAltererUtil.TryCreateStringLiteralByExpression(additiveArgument.Expression));
+                }
+
+                globalOffset += end - start - nonTemplateTokenCount;
+            }
+
+            return null;
         }
 
         public static string TryGetTemplateText(this ICSharpExpression templateExpression)
@@ -139,7 +154,8 @@ namespace ReSharper.Structured.Logging.Extensions
         {
             if (templateExpression is IAdditiveExpression additiveExpression && additiveExpression.ConstantValue.IsString())
             {
-                var argumentInfo = additiveExpression.Arguments.Last();
+                var arguments = additiveExpression.Arguments;
+                var argumentInfo = arguments[arguments.Count - 1];
                 if (argumentInfo is ExpressionArgumentInfo expressionArgumentInfo)
                 {
                     return StringLiteralAltererUtil.TryCreateStringLiteralByExpression(expressionArgumentInfo.Expression);
@@ -294,16 +310,9 @@ namespace ReSharper.Structured.Logging.Extensions
         [CanBeNull]
         private static IPropertyAssignment FindTemplatePropertyAssignment(this IAttribute attribute, string templateParameterName)
         {
-            foreach (var propertyAssignment in attribute.PropertyAssignments)
-            {
-                // The attribute property mirrors the constructor parameter, e.g. `message` and `Message`
-                if (string.Equals(propertyAssignment.PropertyNameIdentifier?.Name, templateParameterName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return propertyAssignment;
-                }
-            }
-
-            return null;
+            // The attribute property mirrors the constructor parameter, e.g. `message` and `Message`
+            return attribute.PropertyAssignments.FirstOrDefault(
+                propertyAssignment => string.Equals(propertyAssignment.PropertyNameIdentifier?.Name, templateParameterName, StringComparison.OrdinalIgnoreCase));
         }
 
         private static void FlattenAdditiveExpression(IAdditiveExpression additiveExpression, LinkedList<ExpressionArgumentInfo> list)

--- a/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
+++ b/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
@@ -260,8 +260,12 @@ namespace ReSharper.Structured.Logging.Extensions
             return StringUtil.Unquote(expressionText);
         }
 
+        /// <summary>
+        /// Returns the name of the parameter holding the message template, or <c>null</c> when the invoked
+        /// member is not a logging member. A <c>null</c> result is the plugin-wide "not a logging call" signal.
+        /// </summary>
         [CanBeNull]
-        private static string GetTemplateParameterName(this ICSharpArgumentsOwner argumentsOwner, TemplateParameterNameAttributeProvider templateParameterNameAttributeProvider)
+        public static string GetTemplateParameterName(this ICSharpArgumentsOwner argumentsOwner, TemplateParameterNameAttributeProvider templateParameterNameAttributeProvider)
         {
             // An attribute usage resolves the invoked constructor through a dedicated reference
             var declaredElement = argumentsOwner is IAttribute attribute

--- a/src/ReSharper.Structured.Logging/Highlighting/DimmedLoggingStatementHighlighting.cs
+++ b/src/ReSharper.Structured.Logging/Highlighting/DimmedLoggingStatementHighlighting.cs
@@ -1,0 +1,45 @@
+using JetBrains.DocumentModel;
+using JetBrains.ReSharper.Feature.Services.Daemon;
+
+namespace ReSharper.Structured.Logging.Highlighting
+{
+    /// <summary>
+    /// Purely decorative: it dims a logging statement so it stops competing with the surrounding code.
+    /// Unlike the other highlightings in this folder it is not an inspection, so it has no configurable
+    /// severity and no error stripe marker; it is toggled through <c>StructuredLoggingSettings</c> instead.
+    /// </summary>
+    [StaticSeverityHighlighting(
+        Severity.INFO,
+        typeof(DimmedLoggingStatementHighlighting.StructuredLoggingHighlightings),
+        AttributeId = StructuredLoggingHighlighterAttributes.DimmedLoggingStatement,
+        OverlapResolve = OverlapResolveKind.NONE,
+        ShowToolTipInStatusBar = false)]
+    public class DimmedLoggingStatementHighlighting : IHighlighting
+    {
+        private readonly DocumentRange _documentRange;
+
+        public DimmedLoggingStatementHighlighting(DocumentRange documentRange)
+        {
+            _documentRange = documentRange;
+        }
+
+        public string ErrorStripeToolTip => null;
+
+        public string ToolTip => null;
+
+        public DocumentRange CalculateRange()
+        {
+            return _documentRange;
+        }
+
+        public bool IsValid()
+        {
+            return _documentRange.IsValid();
+        }
+
+        [RegisterStaticHighlightingsGroup("Structured Logging", false)]
+        public static class StructuredLoggingHighlightings
+        {
+        }
+    }
+}

--- a/src/ReSharper.Structured.Logging/Highlighting/StructuredLoggingHighlighterAttributes.cs
+++ b/src/ReSharper.Structured.Logging/Highlighting/StructuredLoggingHighlighterAttributes.cs
@@ -1,0 +1,23 @@
+using JetBrains.ReSharper.Feature.Services.Daemon.Attributes.Idea;
+using JetBrains.TextControl.DocumentMarkup;
+using JetBrains.TextControl.DocumentMarkup.VisualStudio;
+
+namespace ReSharper.Structured.Logging.Highlighting
+{
+    /// <summary>
+    /// The dimmed appearance mirrors how ReSharper renders dead code: a semi-transparent foreground on the
+    /// dead code layer, which paints over syntax colors but still lets analysis squiggles show through.
+    /// </summary>
+    [RegisterHighlighter(
+        DimmedLoggingStatement,
+        VsPresentableName = "ReSharper Structured Logging Dimmed Statement",
+        RiderReplaceWith = IdeaHighlightingAttributeIds.NOT_USED_ELEMENT_ATTRIBUTES,
+        Layer = HighlighterLayer.DEADCODE,
+        EffectType = EffectType.TEXT,
+        ForegroundOpacity = 0.5,
+        VsGenerateClassificationDefinition = VsGenerateDefinition.VisibleClassification)]
+    public static class StructuredLoggingHighlighterAttributes
+    {
+        public const string DimmedLoggingStatement = "ReSharper Structured Logging Dimmed Statement";
+    }
+}

--- a/src/ReSharper.Structured.Logging/Settings/StructuredLoggingOptionsPage.cs
+++ b/src/ReSharper.Structured.Logging/Settings/StructuredLoggingOptionsPage.cs
@@ -48,6 +48,12 @@ namespace ReSharper.Structured.Logging.Settings
             var ignoredRegex = OptionsSettingsSmartContext
                 .GetValueProperty(lifetime, StructuredLoggingSettingsAccessor.IgnoredPropertiesRegex);
             AddControl(ignoredRegex.GetBeTextBox(lifetime));
+
+            AddHeader("Logging statements appearance");
+            AddBoolOption(
+                StructuredLoggingSettingsAccessor.DimLoggingStatements,
+                "Dim logging statements",
+                "Renders logging statements greyed out, the way unreachable code is rendered, so that they stand out less than the surrounding code.");
         }
     }
 }

--- a/src/ReSharper.Structured.Logging/Settings/StructuredLoggingSettings.cs
+++ b/src/ReSharper.Structured.Logging/Settings/StructuredLoggingSettings.cs
@@ -11,5 +11,8 @@ namespace ReSharper.Structured.Logging.Settings
 
         [SettingsEntry("", "Ignored properties RegEx")]
         public string IgnoredPropertiesRegex { get; set; }
+
+        [SettingsEntry(false, "Dim logging statements")]
+        public bool DimLoggingStatements { get; set; }
     }
 }

--- a/src/ReSharper.Structured.Logging/Settings/StructuredLoggingSettingsAccessor.cs
+++ b/src/ReSharper.Structured.Logging/Settings/StructuredLoggingSettingsAccessor.cs
@@ -12,5 +12,8 @@ namespace ReSharper.Structured.Logging.Settings
 
         [NotNull]
         public static readonly Expression<Func<StructuredLoggingSettings, string>> IgnoredPropertiesRegex = x => x.IgnoredPropertiesRegex;
+
+        [NotNull]
+        public static readonly Expression<Func<StructuredLoggingSettings, bool>> DimLoggingStatements = x => x.DimLoggingStatements;
     }
 }

--- a/src/rider/main/resources/META-INF/plugin.xml
+++ b/src/rider/main/resources/META-INF/plugin.xml
@@ -23,6 +23,11 @@
     </ul>
 
     <p>
+      Logging statements can optionally be dimmed, the way unreachable code is rendered, so that they stand out
+      less than the surrounding code. Enable <b>Dim logging statements</b> in the plugin settings.
+    </p>
+
+    <p>
       Individual analyzers can be turned off per line or per file with a
       <b>// ReSharper disable once &lt;AnalyzerName&gt;</b> comment, or per directory through
       <b>.editorconfig</b>.

--- a/test/data/Analyzers/DimLoggingStatement/DimmingDisabled.cs
+++ b/test/data/Analyzers/DimLoggingStatement/DimmingDisabled.cs
@@ -1,0 +1,12 @@
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            Log.Logger.Information("Greeting {Name}", "world");
+        }
+    }
+}

--- a/test/data/Analyzers/DimLoggingStatement/DimmingDisabled.cs.gold
+++ b/test/data/Analyzers/DimLoggingStatement/DimmingDisabled.cs.gold
@@ -1,0 +1,14 @@
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            Log.Logger.Information("Greeting {Name}", "world");
+        }
+    }
+}
+
+---------------------------------------------------------

--- a/test/data/Analyzers/DimLoggingStatement/LoggingCallInLambda.cs
+++ b/test/data/Analyzers/DimLoggingStatement/LoggingCallInLambda.cs
@@ -1,0 +1,15 @@
+using System;
+
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            Action action = () => Log.Logger.Information("Greeting {Name}", "world");
+            action();
+        }
+    }
+}

--- a/test/data/Analyzers/DimLoggingStatement/LoggingCallInLambda.cs.gold
+++ b/test/data/Analyzers/DimLoggingStatement/LoggingCallInLambda.cs.gold
@@ -1,0 +1,17 @@
+using System;
+
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            Action action = () => Log.Logger.Information("Greeting {Name}", "world");
+            action();
+        }
+    }
+}
+
+---------------------------------------------------------

--- a/test/data/Analyzers/DimLoggingStatement/SerilogLoggingStatement.cs
+++ b/test/data/Analyzers/DimLoggingStatement/SerilogLoggingStatement.cs
@@ -1,0 +1,13 @@
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            var name = "world";
+            Log.Logger.Information("Greeting {Name}", name);
+        }
+    }
+}

--- a/test/data/Analyzers/DimLoggingStatement/SerilogLoggingStatement.cs.gold
+++ b/test/data/Analyzers/DimLoggingStatement/SerilogLoggingStatement.cs.gold
@@ -1,0 +1,16 @@
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            var name = "world";
+            |Log.Logger.Information("Greeting {Name}", name);|(0)
+        }
+    }
+}
+
+---------------------------------------------------------
+(0): ReSharper Structured Logging Dimmed Statement: 

--- a/test/data/Analyzers/DimLoggingStatementDotNet6/AwaitedLoggingStatement.cs
+++ b/test/data/Analyzers/DimLoggingStatementDotNet6/AwaitedLoggingStatement.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading.Tasks;
+
+namespace ConsoleApp
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class MessageTemplateFormatMethodAttribute : Attribute
+    {
+        public MessageTemplateFormatMethodAttribute(string messageTemplateParameterName)
+        {
+            MessageTemplateParameterName = messageTemplateParameterName;
+        }
+
+        public string MessageTemplateParameterName { get; }
+    }
+
+    public static class AsyncLog
+    {
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static Task InformationAsync(string messageTemplate, params object[] propertyValues)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    public static class Program
+    {
+        public static async Task Run(string name)
+        {
+            await AsyncLog.InformationAsync("Greeting {Name}", name);
+        }
+    }
+}

--- a/test/data/Analyzers/DimLoggingStatementDotNet6/AwaitedLoggingStatement.cs.gold
+++ b/test/data/Analyzers/DimLoggingStatementDotNet6/AwaitedLoggingStatement.cs.gold
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace ConsoleApp
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class MessageTemplateFormatMethodAttribute : Attribute
+    {
+        public MessageTemplateFormatMethodAttribute(string messageTemplateParameterName)
+        {
+            MessageTemplateParameterName = messageTemplateParameterName;
+        }
+
+        public string MessageTemplateParameterName { get; }
+    }
+
+    public static class AsyncLog
+    {
+        [MessageTemplateFormatMethod("messageTemplate")]
+        public static Task InformationAsync(string messageTemplate, params object[] propertyValues)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    public static class Program
+    {
+        public static async Task Run(string name)
+        {
+            |await AsyncLog.InformationAsync("Greeting {Name}", name);|(0)
+        }
+    }
+}
+
+---------------------------------------------------------
+(0): ReSharper Structured Logging Dimmed Statement: 

--- a/test/data/Analyzers/DimLoggingStatementDotNet6/MicrosoftLoggingStatement.cs
+++ b/test/data/Analyzers/DimLoggingStatementDotNet6/MicrosoftLoggingStatement.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public class Service
+    {
+        private readonly ILogger<Service> _logger;
+
+        public Service(ILogger<Service> logger)
+        {
+            _logger = logger;
+        }
+
+        public void Connect(string host, int port)
+        {
+            _logger.LogInformation(
+                "Connecting to {Host} on {Port}",
+                host,
+                port);
+        }
+    }
+}

--- a/test/data/Analyzers/DimLoggingStatementDotNet6/MicrosoftLoggingStatement.cs.gold
+++ b/test/data/Analyzers/DimLoggingStatementDotNet6/MicrosoftLoggingStatement.cs.gold
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public class Service
+    {
+        private readonly ILogger<Service> _logger;
+
+        public Service(ILogger<Service> logger)
+        {
+            _logger = logger;
+        }
+
+        public void Connect(string host, int port)
+        {
+            |_logger.LogInformation(
+                "Connecting to {Host} on {Port}",
+                host,
+                port);|(0)
+        }
+    }
+}
+
+---------------------------------------------------------
+(0): ReSharper Structured Logging Dimmed Statement: 

--- a/test/src/Analyzer/DimLoggingStatementAnalyzerTests.cs
+++ b/test/src/Analyzer/DimLoggingStatementAnalyzerTests.cs
@@ -1,0 +1,22 @@
+using JetBrains.Application.Settings;
+
+using NUnit.Framework;
+
+using ReSharper.Structured.Logging.Settings;
+
+namespace ReSharper.Structured.Logging.Tests.Analyzer
+{
+    public class DimLoggingStatementAnalyzerTests : MessageTemplateAnalyzerTestBase
+    {
+        protected override string SubPath => "DimLoggingStatement";
+
+        [Test] public void TestSerilogLoggingStatement() => DoNamedTest2();
+
+        [Test] public void TestLoggingCallInLambda() => DoNamedTest2();
+
+        protected override void MutateSettings(IContextBoundSettingsStore settingsStore)
+        {
+            settingsStore.SetValue<StructuredLoggingSettings, bool>(settings => settings.DimLoggingStatements, true);
+        }
+    }
+}

--- a/test/src/Analyzer/DimLoggingStatementDisabledAnalyzerTests.cs
+++ b/test/src/Analyzer/DimLoggingStatementDisabledAnalyzerTests.cs
@@ -1,0 +1,12 @@
+using NUnit.Framework;
+
+namespace ReSharper.Structured.Logging.Tests.Analyzer
+{
+    // ReSharper disable once TestFileNameWarning
+    public class DimLoggingStatementDisabledAnalyzerTests : MessageTemplateAnalyzerTestBase
+    {
+        protected override string SubPath => "DimLoggingStatement";
+
+        [Test] public void TestDimmingDisabled() => DoNamedTest2();
+    }
+}

--- a/test/src/Analyzer/DimLoggingStatementDotNet6Tests.cs
+++ b/test/src/Analyzer/DimLoggingStatementDotNet6Tests.cs
@@ -1,0 +1,24 @@
+using JetBrains.Application.Settings;
+using JetBrains.ReSharper.TestFramework;
+
+using NUnit.Framework;
+
+using ReSharper.Structured.Logging.Settings;
+
+namespace ReSharper.Structured.Logging.Tests.Analyzer
+{
+    [TestNet60]
+    public class DimLoggingStatementDotNet6Tests : MessageTemplateAnalyzerTestBase
+    {
+        protected override string SubPath => "DimLoggingStatementDotNet6";
+
+        [Test] public void TestMicrosoftLoggingStatement() => DoNamedTest2();
+
+        [Test] public void TestAwaitedLoggingStatement() => DoNamedTest2();
+
+        protected override void MutateSettings(IContextBoundSettingsStore settingsStore)
+        {
+            settingsStore.SetValue<StructuredLoggingSettings, bool>(settings => settings.DimLoggingStatements, true);
+        }
+    }
+}

--- a/test/src/Analyzer/MessageTemplateTests.cs
+++ b/test/src/Analyzer/MessageTemplateTests.cs
@@ -48,7 +48,8 @@ namespace ReSharper.Structured.Logging.Tests.Analyzer
                    || highlighting is PositionalPropertyUsedWarning
                    || highlighting is InconsistentLogPropertyNamingWarning
                    || highlighting is InconsistentContextLogPropertyNamingWarning
-                   || highlighting is LogMessageIsSentenceWarning;
+                   || highlighting is LogMessageIsSentenceWarning
+                   || highlighting is DimmedLoggingStatementHighlighting;
         }
 
         protected virtual void MutateSettings([NotNull] IContextBoundSettingsStore settingsStore)


### PR DESCRIPTION
Closes #19.

Renders logging statements greyed out, the way ReSharper renders dead code, so they stand out less than the surrounding code.

The 2021 answer on the issue was that this is not possible with the R#/Rider SDK, but that was about code folding. What the screenshot in the issue actually shows is a highlighter attribute, which is a supported extension point and, unlike folding, works in both ReSharper and Rider with no Rider frontend changes.

## How it renders

The appearance reuses ReSharper's own dead code recipe: `HighlighterLayer.DEADCODE` with `EffectType.TEXT` and `ForegroundOpacity = 0.5`. The dead code layer paints over syntax colors but sits below the error layer, so analysis squiggles stay visible on a dimmed statement. `RiderReplaceWith = IDEA_NOT_USED_ELEMENT_ATTRIBUTES` makes Rider use its own theme's unused-symbol color.

The highlighting is decoration rather than an inspection, so it is a `[StaticSeverityHighlighting]` with `Severity.INFO` and `OverlapResolveKind.NONE` - no configurable severity entry, no error stripe marker, no `rules/` page.

## What is dimmed

Only a statement that consists of nothing but a logging call, so the whole statement including the trailing semicolon, multi-line calls as a single region, and `await`ed calls together with the `await`. A logging call inside a lambda, an expression-bodied member, or a larger expression keeps its usual colors.

Logging calls are recognized through the existing `TemplateParameterNameAttributeProvider`, so every supported library is covered without new matching logic. `GetTemplateParameterName` became public for this; it was already the plugin-wide "is this a logging call" signal.

## Setting

`Dim logging statements`, **off by default**, under Settings -> Environment -> Structured Logging. The Rider options page mirrors the backend page by id, so the checkbox shows up there without a frontend change.

## Validation

- `build.cmd Test` - 103/103
- `build.cmd Test --is-rider-host` - 103/103
- Manual check in a sandboxed Rider via `build.cmd RunIde --is-rider-host`, including that an existing naming warning still squiggles through a dimmed statement

New analyzer tests cover Serilog and Microsoft.Extensions.Logging statements, a multi-line statement, an awaited call, a logging call in a lambda that must stay undimmed, and the setting-off case.
