### PR TITLE
Bind template holes semantically and add three quick fixes

### DIFF
--- a/src/ReSharper.Structured.Logging/Analyzer/AnonymousTypeDestructureAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/AnonymousTypeDestructureAnalyzer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 
 using JetBrains.ReSharper.Feature.Services.Daemon;
-using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CodeAnnotations;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 
@@ -20,10 +19,13 @@ namespace ReSharper.Structured.Logging.Analyzer
 
         private readonly Lazy<TemplateParameterNameAttributeProvider> _templateParameterNameAttributeProvider;
 
-        public AnonymousTypeDestructureAnalyzer(MessageTemplateParser messageTemplateParser, CodeAnnotationsCache codeAnnotationsCache)
+        public AnonymousTypeDestructureAnalyzer(
+            MessageTemplateParser messageTemplateParser,
+            CodeAnnotationsCache codeAnnotationsCache)
         {
             _messageTemplateParser = messageTemplateParser;
-            _templateParameterNameAttributeProvider = codeAnnotationsCache.GetLazyProvider<TemplateParameterNameAttributeProvider>();
+            _templateParameterNameAttributeProvider =
+                codeAnnotationsCache.GetLazyProvider<TemplateParameterNameAttributeProvider>();
         }
 
         protected override void Run(
@@ -44,10 +46,8 @@ namespace ReSharper.Structured.Logging.Analyzer
                 return;
             }
 
-            var anonymousObjectsArguments = element.ArgumentList.Arguments
-                .Where(a => a.Value is IAnonymousObjectCreationExpression)
-                .ToArray();
-            if (anonymousObjectsArguments.Length == 0)
+            var holeArguments = element.GetTemplateHoleArguments(templateArgument);
+            if (holeArguments == null || !holeArguments.Any(a => a.Value is IAnonymousObjectCreationExpression))
             {
                 return;
             }
@@ -64,21 +64,22 @@ namespace ReSharper.Structured.Logging.Analyzer
                 return;
             }
 
-            var templateArgumentIndex = templateArgument.IndexOf();
-            foreach (var argument in anonymousObjectsArguments)
+            var holeCount = Math.Min(holeArguments.Count, messageTemplate.NamedProperties.Length);
+            for (var index = 0; index < holeCount; index++)
             {
-                var index = argument.IndexOf() - templateArgumentIndex - 1;
-                if (index < messageTemplate.NamedProperties.Length)
+                if (!(holeArguments[index].Value is IAnonymousObjectCreationExpression))
                 {
-                    var namedProperty = messageTemplate.NamedProperties[index];
-                    if (namedProperty.Destructuring != Destructuring.Default)
-                    {
-                        continue;
-                    }
-
-                    var tokenInformation = templateArgument.Value.GetTokenInformation(namedProperty);
-                    consumer.AddHighlighting(new AnonymousObjectDestructuringWarning(tokenInformation));
+                    continue;
                 }
+
+                var namedProperty = messageTemplate.NamedProperties[index];
+                if (namedProperty.Destructuring != Destructuring.Default)
+                {
+                    continue;
+                }
+
+                var tokenInformation = templateArgument.Value.GetTokenInformation(namedProperty);
+                consumer.AddHighlighting(new AnonymousObjectDestructuringWarning(tokenInformation));
             }
         }
     }

--- a/src/ReSharper.Structured.Logging/Analyzer/ComplexObjectDestructureAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/ComplexObjectDestructureAnalyzer.cs
@@ -19,16 +19,20 @@ namespace ReSharper.Structured.Logging.Analyzer
     [ElementProblemAnalyzer(typeof(IInvocationExpression))]
     public class ComplexObjectDestructureAnalyzer : ElementProblemAnalyzer<IInvocationExpression>
     {
-        private static readonly IClrTypeName GenericDictionaryFqn = new ClrTypeName("System.Collections.Generic.Dictionary`2");
+        private static readonly IClrTypeName GenericDictionaryFqn =
+            new ClrTypeName("System.Collections.Generic.Dictionary`2");
 
         private readonly MessageTemplateParser _messageTemplateParser;
 
         private readonly Lazy<TemplateParameterNameAttributeProvider> _templateParameterNameAttributeProvider;
 
-        public ComplexObjectDestructureAnalyzer(MessageTemplateParser messageTemplateParser, CodeAnnotationsCache codeAnnotationsCache)
+        public ComplexObjectDestructureAnalyzer(
+            MessageTemplateParser messageTemplateParser,
+            CodeAnnotationsCache codeAnnotationsCache)
         {
             _messageTemplateParser = messageTemplateParser;
-            _templateParameterNameAttributeProvider = codeAnnotationsCache.GetLazyProvider<TemplateParameterNameAttributeProvider>();
+            _templateParameterNameAttributeProvider =
+                codeAnnotationsCache.GetLazyProvider<TemplateParameterNameAttributeProvider>();
         }
 
         protected override void Run(
@@ -89,31 +93,28 @@ namespace ReSharper.Structured.Logging.Analyzer
                 return;
             }
 
-            var templateArgumentIndex = templateArgument.IndexOf();
-            var complexObject = element.ArgumentList.Arguments
-                .Where(a => a.IndexOf() > templateArgumentIndex)
-                .Where(CheckIfDestructureNeeded)
-                .ToArray();
-
-            if (complexObject.Length == 0)
+            var holeArguments = element.GetTemplateHoleArguments(templateArgument);
+            if (holeArguments == null)
             {
                 return;
             }
 
-            foreach (var argument in complexObject)
+            var holeCount = Math.Min(holeArguments.Count, messageTemplate.NamedProperties.Length);
+            for (var index = 0; index < holeCount; index++)
             {
-                var index = argument.IndexOf() - templateArgumentIndex - 1;
-                if (index < messageTemplate.NamedProperties.Length)
+                var namedProperty = messageTemplate.NamedProperties[index];
+                if (namedProperty.Destructuring != Destructuring.Default)
                 {
-                    var namedProperty = messageTemplate.NamedProperties[index];
-                    if (namedProperty.Destructuring != Destructuring.Default)
-                    {
-                        continue;
-                    }
-
-                    consumer.AddHighlighting(
-                        new ComplexObjectDestructuringWarning(templateArgument.Value.GetTokenInformation(namedProperty)));
+                    continue;
                 }
+
+                if (!CheckIfDestructureNeeded(holeArguments[index]))
+                {
+                    continue;
+                }
+
+                consumer.AddHighlighting(
+                    new ComplexObjectDestructuringWarning(templateArgument.Value.GetTokenInformation(namedProperty)));
             }
         }
 
@@ -159,7 +160,8 @@ namespace ReSharper.Structured.Logging.Analyzer
             }
 
             // ReSharper disable once StyleCop.SA1305
-            var iType = argument.GetExpressionType().ToIType();
+            var iType = argument.GetExpressionType()
+                .ToIType();
             if (iType == null)
             {
                 return false;

--- a/src/ReSharper.Structured.Logging/Analyzer/CorrectExceptionPassingAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/CorrectExceptionPassingAnalyzer.cs
@@ -78,9 +78,44 @@ namespace ReSharper.Structured.Logging.Analyzer
             consumer.AddHighlighting(
                 new ExceptionPassedAsTemplateArgumentWarning(
                     holeArguments[exceptionHoleIndex],
+                    templateArgument,
                     element,
                     tokenInformation,
-                    namedProperty));
+                    namedProperty,
+                    IsExceptionArgumentOccupied(element, templateArgument, exceptionType)));
+        }
+
+        /// <summary>
+        /// Reports whether an exception is already bound to a parameter before the template, that is whether the
+        /// dedicated exception argument is taken.
+        /// </summary>
+        private static bool IsExceptionArgumentOccupied(
+            [NotNull] IInvocationExpression invocationExpression,
+            [NotNull] ICSharpArgument templateArgument,
+            [NotNull] IDeclaredType exceptionType)
+        {
+            var templateParameter = templateArgument.MatchingParameter?.Element;
+            if (templateParameter == null)
+            {
+                return false;
+            }
+
+            var templateParameterIndex = templateParameter.IndexOf();
+            foreach (var argument in invocationExpression.ArgumentList.Arguments)
+            {
+                var parameter = argument.MatchingParameter?.Element;
+                if (parameter == null || parameter.IndexOf() >= templateParameterIndex)
+                {
+                    continue;
+                }
+
+                if (argument.Value?.Type() is IDeclaredType declaredType && declaredType.IsSubtypeOf(exceptionType))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static int FindExceptionHoleIndex(

--- a/src/ReSharper.Structured.Logging/Analyzer/CorrectExceptionPassingAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/CorrectExceptionPassingAnalyzer.cs
@@ -1,5 +1,7 @@
 using System;
-using System.Linq;
+using System.Collections.Generic;
+
+using JetBrains.Annotations;
 using JetBrains.Metadata.Reader.API;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi;
@@ -10,20 +12,26 @@ using JetBrains.ReSharper.Psi.Util;
 using ReSharper.Structured.Logging.Caching;
 using ReSharper.Structured.Logging.Extensions;
 using ReSharper.Structured.Logging.Highlighting;
+using ReSharper.Structured.Logging.Serilog.Parsing;
 
 namespace ReSharper.Structured.Logging.Analyzer
 {
     [ElementProblemAnalyzer(typeof(IInvocationExpression))]
     public class CorrectExceptionPassingAnalyzer : ElementProblemAnalyzer<IInvocationExpression>
     {
+        private readonly MessageTemplateParser _messageTemplateParser;
+
         private readonly Lazy<TemplateParameterNameAttributeProvider> _templateParameterNameAttributeProvider;
 
-        public CorrectExceptionPassingAnalyzer(CodeAnnotationsCache codeAnnotationsCache)
+        public CorrectExceptionPassingAnalyzer(
+            MessageTemplateParser messageTemplateParser,
+            CodeAnnotationsCache codeAnnotationsCache)
         {
-            _templateParameterNameAttributeProvider = codeAnnotationsCache.GetLazyProvider<TemplateParameterNameAttributeProvider>();
+            _messageTemplateParser = messageTemplateParser;
+            _templateParameterNameAttributeProvider =
+                codeAnnotationsCache.GetLazyProvider<TemplateParameterNameAttributeProvider>();
         }
 
-        // ReSharper disable once CognitiveComplexity
         protected override void Run(
             IInvocationExpression element,
             ElementProblemAnalyzerData data,
@@ -35,81 +43,130 @@ namespace ReSharper.Structured.Logging.Analyzer
                 return;
             }
 
-            var exceptionType = element.PsiModule.GetPredefinedType().TryGetType(PredefinedType.EXCEPTION_FQN, NullableAnnotation.Unknown);
+            var exceptionType = element.PsiModule.GetPredefinedType()
+                .TryGetType(PredefinedType.EXCEPTION_FQN, NullableAnnotation.Unknown);
             if (exceptionType == null)
             {
                 return;
             }
 
-            ICSharpArgument invalidExceptionArgument = FindInvalidExceptionArgument(element, templateArgument, exceptionType);
-            if (invalidExceptionArgument == null)
+            // Only the arguments bound to a parameter after the template are consumed as hole values.
+            // An exception in the dedicated exception slot is bound before the template and is therefore
+            // never a hole, no matter where it appears in the source
+            var holeArguments = element.GetTemplateHoleArguments(templateArgument);
+            if (holeArguments == null)
             {
                 return;
             }
 
-            var overloadAvailable = false;
-            var candidates = element.InvocationExpressionReference.GetCandidates().ToArray();
-            var invalidArgumentIndex = invalidExceptionArgument.IndexOf();
-            foreach (var candidate in candidates)
+            var exceptionHoleIndex = FindExceptionHoleIndex(holeArguments, exceptionType);
+            if (exceptionHoleIndex < 0)
+            {
+                return;
+            }
+
+            if (!IsExceptionOverloadAvailable(element, templateArgument, exceptionType))
+            {
+                return;
+            }
+
+            var namedProperty = TryGetHoleProperty(templateArgument, exceptionHoleIndex);
+            var tokenInformation = namedProperty == null
+                ? null
+                : templateArgument.Value.GetTokenInformation(namedProperty);
+
+            consumer.AddHighlighting(
+                new ExceptionPassedAsTemplateArgumentWarning(
+                    holeArguments[exceptionHoleIndex],
+                    element,
+                    tokenInformation,
+                    namedProperty));
+        }
+
+        private static int FindExceptionHoleIndex(
+            [NotNull] IReadOnlyList<ICSharpArgument> holeArguments,
+            [NotNull] IDeclaredType exceptionType)
+        {
+            for (var index = 0; index < holeArguments.Count; index++)
+            {
+                if (holeArguments[index]
+                        .Value?.Type() is IDeclaredType declaredType
+                    && declaredType.IsSubtypeOf(exceptionType))
+                {
+                    return index;
+                }
+            }
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Reports whether the exception could be moved at all, that is whether any candidate overload declares
+        /// an exception parameter before the template parameter. Both indices are declaration positions, so this
+        /// stays correct for named and reordered arguments.
+        /// </summary>
+        private static bool IsExceptionOverloadAvailable(
+            [NotNull] IInvocationExpression invocationExpression,
+            [NotNull] ICSharpArgument templateArgument,
+            [NotNull] IDeclaredType exceptionType)
+        {
+            var templateParameterName = templateArgument.MatchingParameter?.Element.ShortName;
+            if (templateParameterName == null)
+            {
+                return false;
+            }
+
+            foreach (var candidate in invocationExpression.InvocationExpressionReference.GetCandidates())
             {
                 if (!(candidate.GetDeclaredElement() is IMethod declaredElement))
                 {
                     continue;
                 }
 
-                foreach (var parameter in declaredElement.Parameters)
+                var parameters = declaredElement.Parameters;
+                for (var index = 0; index < parameters.Count; index++)
                 {
-                    if (invalidArgumentIndex <= parameter.IndexOf())
+                    if (parameters[index].ShortName == templateParameterName)
                     {
                         break;
                     }
 
-                    if (parameter.Type.IsSubtypeOf(exceptionType))
+                    if (parameters[index]
+                        .Type.IsSubtypeOf(exceptionType))
                     {
-                        overloadAvailable = true;
-                        break;
+                        return true;
                     }
                 }
-
-                if (overloadAvailable)
-                {
-                    break;
-                }
             }
 
-            if (!overloadAvailable)
-            {
-                return;
-            }
-
-            consumer.AddHighlighting(new ExceptionPassedAsTemplateArgumentWarning(invalidExceptionArgument.GetDocumentRange()));
+            return false;
         }
 
-        private ICSharpArgument FindInvalidExceptionArgument(IInvocationExpression invocationExpression, ICSharpArgument templateArgument, IDeclaredType exceptionType)
+        /// <summary>
+        /// Returns the template hole the exception fills, or <c>null</c> when the template is not a literal whose
+        /// holes can be located. The quick fix then moves the argument without touching the message.
+        /// </summary>
+        [CanBeNull]
+        private PropertyToken TryGetHoleProperty([NotNull] ICSharpArgument templateArgument, int holeIndex)
         {
-            var templateArgumentIndex = templateArgument.IndexOf();
-            foreach (var argument in invocationExpression.ArgumentList.Arguments)
+            if (templateArgument.Value is IInterpolatedStringExpression)
             {
-                var argumentType = argument.Value?.Type();
-                if (!(argumentType is IDeclaredType declaredType))
-                {
-                    continue;
-                }
-
-                if (!declaredType.IsSubtypeOf(exceptionType))
-                {
-                    continue;
-                }
-
-                if (templateArgumentIndex > argument.IndexOf())
-                {
-                    return null;
-                }
-
-                return argument;
+                return null;
             }
 
-            return null;
+            var templateText = templateArgument.Value.TryGetTemplateText();
+            if (templateText == null)
+            {
+                return null;
+            }
+
+            var messageTemplate = _messageTemplateParser.Parse(templateText);
+            if (messageTemplate.NamedProperties == null || holeIndex >= messageTemplate.NamedProperties.Length)
+            {
+                return null;
+            }
+
+            return messageTemplate.NamedProperties[holeIndex];
         }
     }
 }

--- a/src/ReSharper.Structured.Logging/Analyzer/DuplicatePropertiesTemplateAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/DuplicatePropertiesTemplateAnalyzer.cs
@@ -19,10 +19,13 @@ namespace ReSharper.Structured.Logging.Analyzer
 
         private readonly Lazy<TemplateParameterNameAttributeProvider> _templateParameterNameAttributeProvider;
 
-        public DuplicatePropertiesTemplateAnalyzer(MessageTemplateParser messageTemplateParser, CodeAnnotationsCache codeAnnotationsCache)
+        public DuplicatePropertiesTemplateAnalyzer(
+            MessageTemplateParser messageTemplateParser,
+            CodeAnnotationsCache codeAnnotationsCache)
         {
             _messageTemplateParser = messageTemplateParser;
-            _templateParameterNameAttributeProvider = codeAnnotationsCache.GetLazyProvider<TemplateParameterNameAttributeProvider>();
+            _templateParameterNameAttributeProvider =
+                codeAnnotationsCache.GetLazyProvider<TemplateParameterNameAttributeProvider>();
         }
 
         protected override void Run(
@@ -43,13 +46,27 @@ namespace ReSharper.Structured.Logging.Analyzer
                 return;
             }
 
+            var holeArguments = element.GetTemplateHoleArguments(_templateParameterNameAttributeProvider.Value);
+            var usedPropertyNames = messageTemplate.NamedProperties.Select(n => n.PropertyName)
+                .ToArray();
+
             foreach (var duplicates in messageTemplate.NamedProperties
-                .GroupBy(n => n.PropertyName)
-                .Where(g => g.Count() > 1))
+                         .GroupBy(n => n.PropertyName)
+                         .Where(g => g.Count() > 1))
             {
                 foreach (var token in duplicates)
                 {
-                    consumer.AddHighlighting(new DuplicateTemplatePropertyWarning(templateExpression.GetTokenInformation(token)));
+                    var holeIndex = Array.IndexOf(messageTemplate.NamedProperties, token);
+                    var argument = holeArguments != null && holeIndex >= 0 && holeIndex < holeArguments.Count
+                        ? holeArguments[holeIndex]
+                        : null;
+
+                    consumer.AddHighlighting(
+                        new DuplicateTemplatePropertyWarning(
+                            templateExpression.GetTokenInformation(token),
+                            token,
+                            argument,
+                            usedPropertyNames));
                 }
             }
         }

--- a/src/ReSharper.Structured.Logging/Analyzer/PositionalPropertiesUsageAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/PositionalPropertiesUsageAnalyzer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CodeAnnotations;
@@ -18,10 +19,13 @@ namespace ReSharper.Structured.Logging.Analyzer
 
         private readonly Lazy<TemplateParameterNameAttributeProvider> _templateParameterNameAttributeProvider;
 
-        public PositionalPropertiesUsageAnalyzer(MessageTemplateParser messageTemplateParser, CodeAnnotationsCache codeAnnotationsCache)
+        public PositionalPropertiesUsageAnalyzer(
+            MessageTemplateParser messageTemplateParser,
+            CodeAnnotationsCache codeAnnotationsCache)
         {
             _messageTemplateParser = messageTemplateParser;
-            _templateParameterNameAttributeProvider = codeAnnotationsCache.GetLazyProvider<TemplateParameterNameAttributeProvider>();
+            _templateParameterNameAttributeProvider =
+                codeAnnotationsCache.GetLazyProvider<TemplateParameterNameAttributeProvider>();
         }
 
         protected override void Run(
@@ -42,9 +46,25 @@ namespace ReSharper.Structured.Logging.Analyzer
                 return;
             }
 
+            var holeArguments = element.GetTemplateHoleArguments(_templateParameterNameAttributeProvider.Value);
+            var usedPropertyNames = messageTemplate.PositionalProperties.Select(p => p.PropertyName)
+                .ToArray();
+
             foreach (var property in messageTemplate.PositionalProperties)
             {
-                consumer.AddHighlighting(new PositionalPropertyUsedWarning(templateExpression.GetTokenInformation(property)));
+                // A positional hole names the argument it takes, so {1} is filled by the second value
+                var argument = holeArguments != null
+                               && property.TryGetPositionalValue(out var position)
+                               && position < holeArguments.Count
+                    ? holeArguments[position]
+                    : null;
+
+                consumer.AddHighlighting(
+                    new PositionalPropertyUsedWarning(
+                        templateExpression.GetTokenInformation(property),
+                        property,
+                        argument,
+                        usedPropertyNames));
             }
         }
     }

--- a/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
+++ b/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
@@ -104,6 +104,29 @@ namespace ReSharper.Structured.Logging.Extensions
         }
 
         /// <summary>
+        /// The <see cref="ICSharpArgumentsOwner"/> overload of the hole binder. An attribute template has no
+        /// arguments filling its holes, and the holes of LoggerMessage.Define are filled by generic type
+        /// parameters, so both return <c>null</c>.
+        /// </summary>
+        [CanBeNull]
+        public static IReadOnlyList<ICSharpArgument> GetTemplateHoleArguments(
+            this ICSharpArgumentsOwner argumentsOwner,
+            TemplateParameterNameAttributeProvider templateParameterNameAttributeProvider)
+        {
+            if (!(argumentsOwner is IInvocationExpression invocationExpression)
+                || invocationExpression.IsLoggerMessageDefineMethod())
+            {
+                return null;
+            }
+
+            var templateArgument = invocationExpression.GetTemplateArgument(templateParameterNameAttributeProvider);
+
+            return templateArgument == null
+                ? null
+                : invocationExpression.GetTemplateHoleArguments(templateArgument);
+        }
+
+        /// <summary>
         /// Returns the message template expression of a logging call or of a logging attribute
         /// such as [LoggerMessage(Message = "...")].
         /// </summary>

--- a/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
+++ b/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
@@ -7,9 +7,11 @@ using JetBrains.DocumentModel;
 using JetBrains.Metadata.Reader.API;
 using JetBrains.Metadata.Reader.Impl;
 using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.CSharp.Impl.Resolve;
 using JetBrains.ReSharper.Psi.CSharp.Parsing;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.CSharp.Util;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.ReSharper.Psi.Util;
 using JetBrains.Util;
@@ -24,16 +26,81 @@ namespace ReSharper.Structured.Logging.Extensions
     {
         private static readonly IClrTypeName LogContextFqn = new ClrTypeName("Serilog.Context.LogContext");
 
-        private static readonly IClrTypeName LoggerMessageFqn = new ClrTypeName("Microsoft.Extensions.Logging.LoggerMessage");
+        private static readonly IClrTypeName LoggerMessageFqn =
+            new ClrTypeName("Microsoft.Extensions.Logging.LoggerMessage");
 
         [CanBeNull]
-        public static ICSharpArgument GetTemplateArgument(this IInvocationExpression invocationExpression, TemplateParameterNameAttributeProvider templateParameterNameAttributeProvider)
+        public static ICSharpArgument GetTemplateArgument(
+            this IInvocationExpression invocationExpression,
+            TemplateParameterNameAttributeProvider templateParameterNameAttributeProvider)
         {
-            var templateParameterName = invocationExpression.GetTemplateParameterName(templateParameterNameAttributeProvider);
+            var templateParameterName =
+                invocationExpression.GetTemplateParameterName(templateParameterNameAttributeProvider);
 
             return string.IsNullOrEmpty(templateParameterName)
-                       ? null
-                       : invocationExpression.FindTemplateArgument(templateParameterName);
+                ? null
+                : invocationExpression.FindTemplateArgument(templateParameterName);
+        }
+
+        /// <summary>
+        /// Returns the arguments that fill the template holes, ordered by the parameter they are bound to,
+        /// or <c>null</c> when the hole values cannot be tied to expressions because they were passed as a
+        /// single array instead of being expanded.
+        /// </summary>
+        /// <remarks>
+        /// A hole value is any argument bound to a parameter declared after the template parameter. That covers
+        /// both the <c>params</c> overload and the generic ones Serilog resolves for short argument lists, and it
+        /// excludes the dedicated exception slot, the event id and the extension receiver, which all come before
+        /// the template. Binding through <see cref="ICSharpArgumentInfo.MatchingParameter"/> rather than through
+        /// the argument position keeps the mapping correct for named, reordered and omitted optional arguments.
+        /// </remarks>
+        [CanBeNull]
+        public static IReadOnlyList<ICSharpArgument> GetTemplateHoleArguments(
+            this IInvocationExpression invocationExpression,
+            [NotNull] ICSharpArgument templateArgument)
+        {
+            var templateParameter = templateArgument.MatchingParameter?.Element;
+            if (templateParameter == null)
+            {
+                return null;
+            }
+
+            var templateParameterIndex = templateParameter.IndexOf();
+            var holeArguments = new List<(int ParameterIndex, int ArgumentIndex, ICSharpArgument Argument)>();
+            foreach (var argument in invocationExpression.ArgumentList.Arguments)
+            {
+                var parameterInstance = argument.MatchingParameter;
+                var parameter = parameterInstance?.Element;
+                if (parameter == null || !Equals(
+                        parameter.ContainingParametersOwner,
+                        templateParameter.ContainingParametersOwner))
+                {
+                    continue;
+                }
+
+                var parameterIndex = parameter.IndexOf();
+                if (parameterIndex <= templateParameterIndex)
+                {
+                    continue;
+                }
+
+                // A single array passed to the params parameter hides the individual values,
+                // so no hole can be tied to an expression
+                if (parameter.IsParams && parameterInstance.Expanded != ArgumentsUtil.ExpandedKind.Expanded)
+                {
+                    return null;
+                }
+
+                holeArguments.Add((parameterIndex, argument.IndexOf(), argument));
+            }
+
+            // Several arguments share the parameter index when the params parameter is expanded,
+            // their source order is the hole order
+            return holeArguments
+                .OrderBy(a => a.ParameterIndex)
+                .ThenBy(a => a.ArgumentIndex)
+                .Select(a => a.Argument)
+                .ToArray();
         }
 
         /// <summary>
@@ -41,7 +108,9 @@ namespace ReSharper.Structured.Logging.Extensions
         /// such as [LoggerMessage(Message = "...")].
         /// </summary>
         [CanBeNull]
-        public static ICSharpExpression GetTemplateExpression(this ICSharpArgumentsOwner argumentsOwner, TemplateParameterNameAttributeProvider templateParameterNameAttributeProvider)
+        public static ICSharpExpression GetTemplateExpression(
+            this ICSharpArgumentsOwner argumentsOwner,
+            TemplateParameterNameAttributeProvider templateParameterNameAttributeProvider)
         {
             var templateParameterName = argumentsOwner.GetTemplateParameterName(templateParameterNameAttributeProvider);
             if (string.IsNullOrEmpty(templateParameterName))
@@ -58,24 +127,31 @@ namespace ReSharper.Structured.Logging.Extensions
             // An attribute can also carry the template in a named property, e.g. [LoggerMessage(Message = "...")]
             if (argumentsOwner is IAttribute attribute)
             {
-                return attribute.FindTemplatePropertyAssignment(templateParameterName)?.Source;
+                return attribute.FindTemplatePropertyAssignment(templateParameterName)
+                    ?.Source;
             }
 
             return null;
         }
 
-        public static MessageTemplateTokenInformation GetTokenInformation(this ICSharpExpression templateExpression, MessageTemplateToken token)
+        public static MessageTemplateTokenInformation GetTokenInformation(
+            this ICSharpExpression templateExpression,
+            MessageTemplateToken token)
         {
             var (tokenTextRange, tokenArgument) = FindTokenTextRange(templateExpression, token);
-            var tokenDocument = templateExpression.GetDocumentRange().Document;
+            var tokenDocument = templateExpression.GetDocumentRange()
+                .Document;
             var documentRange = new DocumentRange(tokenDocument, tokenTextRange);
 
             return new MessageTemplateTokenInformation(documentRange, tokenArgument);
         }
 
-        private static (TextRange, IStringLiteralAlterer) FindTokenTextRange(this ICSharpExpression templateExpression, MessageTemplateToken token)
+        private static (TextRange, IStringLiteralAlterer) FindTokenTextRange(
+            this ICSharpExpression templateExpression,
+            MessageTemplateToken token)
         {
-            if (templateExpression is IAdditiveExpression additiveExpression && additiveExpression.ConstantValue.IsString())
+            if (templateExpression is IAdditiveExpression additiveExpression &&
+                additiveExpression.ConstantValue.IsString())
             {
                 var concatenatedRange = FindTokenTextRangeInConcatenation(additiveExpression, token);
                 if (concatenatedRange.HasValue)
@@ -84,14 +160,16 @@ namespace ReSharper.Structured.Logging.Extensions
                 }
             }
 
-            var startOffset = templateExpression.GetDocumentRange().TextRange.StartOffset + token.StartIndex + 1;
+            var startOffset = templateExpression.GetDocumentRange()
+                .TextRange.StartOffset + token.StartIndex + 1;
             if (templateExpression.IsVerbatimString())
             {
                 startOffset++;
             }
 
             // ReSharper disable once AssignNullToNotNullAttribute
-            return (new TextRange(startOffset, startOffset + token.Length), StringLiteralAltererUtil.TryCreateStringLiteralByExpression(templateExpression));
+            return (new TextRange(startOffset, startOffset + token.Length),
+                StringLiteralAltererUtil.TryCreateStringLiteralByExpression(templateExpression));
         }
 
         /// <summary>
@@ -99,7 +177,9 @@ namespace ReSharper.Structured.Logging.Extensions
         /// fragment contributes, and returns the range of the fragment the token falls into, or <c>null</c>
         /// when the token lies past the end of the concatenation.
         /// </summary>
-        private static (TextRange, IStringLiteralAlterer)? FindTokenTextRangeInConcatenation(IAdditiveExpression additiveExpression, MessageTemplateToken token)
+        private static (TextRange, IStringLiteralAlterer)? FindTokenTextRangeInConcatenation(
+            IAdditiveExpression additiveExpression,
+            MessageTemplateToken token)
         {
             var arguments = new LinkedList<ExpressionArgumentInfo>();
             FlattenAdditiveExpression(additiveExpression, arguments);
@@ -127,7 +207,8 @@ namespace ReSharper.Structured.Logging.Extensions
 
                     var tokenEndIndex = tokenStartIndex + token.Length;
 
-                    return (new TextRange(tokenStartIndex, end > tokenEndIndex ? tokenEndIndex : end), StringLiteralAltererUtil.TryCreateStringLiteralByExpression(additiveArgument.Expression));
+                    return (new TextRange(tokenStartIndex, end > tokenEndIndex ? tokenEndIndex : end),
+                        StringLiteralAltererUtil.TryCreateStringLiteralByExpression(additiveArgument.Expression));
                 }
 
                 globalOffset += end - start - nonTemplateTokenCount;
@@ -138,7 +219,8 @@ namespace ReSharper.Structured.Logging.Extensions
 
         public static string TryGetTemplateText(this ICSharpExpression templateExpression)
         {
-            if (templateExpression is IAdditiveExpression additiveExpression && additiveExpression.ConstantValue.IsString())
+            if (templateExpression is IAdditiveExpression additiveExpression &&
+                additiveExpression.ConstantValue.IsString())
             {
                 var linkedList = new LinkedList<ExpressionArgumentInfo>();
                 FlattenAdditiveExpression(additiveExpression, linkedList);
@@ -150,43 +232,51 @@ namespace ReSharper.Structured.Logging.Extensions
         }
 
         [CanBeNull]
-        public static IStringLiteralAlterer TryCreateLastTemplateFragmentExpression(this ICSharpExpression templateExpression)
+        public static IStringLiteralAlterer TryCreateLastTemplateFragmentExpression(
+            this ICSharpExpression templateExpression)
         {
-            if (templateExpression is IAdditiveExpression additiveExpression && additiveExpression.ConstantValue.IsString())
+            if (templateExpression is IAdditiveExpression additiveExpression &&
+                additiveExpression.ConstantValue.IsString())
             {
                 var arguments = additiveExpression.Arguments;
                 var argumentInfo = arguments[arguments.Count - 1];
                 if (argumentInfo is ExpressionArgumentInfo expressionArgumentInfo)
                 {
-                    return StringLiteralAltererUtil.TryCreateStringLiteralByExpression(expressionArgumentInfo.Expression);
+                    return StringLiteralAltererUtil.TryCreateStringLiteralByExpression(
+                        expressionArgumentInfo.Expression);
                 }
 
                 return null;
             }
 
-            return templateExpression == null ? null : StringLiteralAltererUtil.TryCreateStringLiteralByExpression(templateExpression);
+            return templateExpression == null
+                ? null
+                : StringLiteralAltererUtil.TryCreateStringLiteralByExpression(templateExpression);
         }
 
-        public static bool IsGenericMicrosoftExtensionsLogger([NotNull]this IDeclaredType declared)
+        public static bool IsGenericMicrosoftExtensionsLogger([NotNull] this IDeclaredType declared)
         {
-            return declared.GetClrName().FullName == "Microsoft.Extensions.Logging.ILogger`1";
+            return declared.GetClrName()
+                .FullName == "Microsoft.Extensions.Logging.ILogger`1";
         }
 
-        public static bool IsSerilogContextFactoryLogger([NotNull]this IInvocationExpression invocationExpression)
+        public static bool IsSerilogContextFactoryLogger([NotNull] this IInvocationExpression invocationExpression)
         {
             if (invocationExpression.TypeArguments.Count != 1)
             {
                 return false;
             }
 
-            var declaredElement = invocationExpression.Reference.Resolve().DeclaredElement as IClrDeclaredElement;
+            var declaredElement = invocationExpression.Reference.Resolve()
+                .DeclaredElement as IClrDeclaredElement;
             var containingType = declaredElement?.GetContainingType();
             if (containingType == null)
             {
                 return false;
             }
 
-            if (containingType.GetClrName().FullName == "Serilog.ILogger" && declaredElement.ShortName == "ForContext")
+            if (containingType.GetClrName()
+                    .FullName == "Serilog.ILogger" && declaredElement.ShortName == "ForContext")
             {
                 return true;
             }
@@ -200,7 +290,8 @@ namespace ReSharper.Structured.Logging.Extensions
         /// </summary>
         public static bool IsLoggerMessageDefineMethod(this IInvocationExpression invocationExpression)
         {
-            var typeMember = invocationExpression.Reference?.Resolve().DeclaredElement as ITypeMember;
+            var typeMember = invocationExpression.Reference?.Resolve()
+                .DeclaredElement as ITypeMember;
             var containingType = typeMember?.GetContainingType();
             if (containingType == null)
             {
@@ -212,7 +303,8 @@ namespace ReSharper.Structured.Logging.Extensions
 
         public static bool IsSerilogContextPushPropertyMethod(this IInvocationExpression invocationExpression)
         {
-            var typeMember = invocationExpression.Reference.Resolve().DeclaredElement as ITypeMember;
+            var typeMember = invocationExpression.Reference.Resolve()
+                .DeclaredElement as ITypeMember;
             var containingType = typeMember?.GetContainingType();
             if (containingType == null)
             {
@@ -223,7 +315,7 @@ namespace ReSharper.Structured.Logging.Extensions
         }
 
         [CanBeNull]
-        public static IType GetFirstGenericArgumentType([NotNull]this IDeclaredType declared)
+        public static IType GetFirstGenericArgumentType([NotNull] this IDeclaredType declared)
         {
             var substitution = declared.GetSubstitution();
             var typeParameter = substitution.Domain.FirstOrDefault();
@@ -236,20 +328,20 @@ namespace ReSharper.Structured.Logging.Extensions
         }
 
         [CanBeNull]
-        public static ITypeUsage GetFirstTypeArgumentNode([CanBeNull]this ITypeUsage typeUsage)
+        public static ITypeUsage GetFirstTypeArgumentNode([CanBeNull] this ITypeUsage typeUsage)
         {
             return (typeUsage as IUserTypeUsage)?.ScalarTypeName?.TypeArgumentList?.TypeArgumentNodes
                 .FirstOrDefault();
         }
 
         [CanBeNull]
-        public static ITypeUsage GetFirstTypeArgumentNode([CanBeNull]this IInvocationExpression invocationExpression)
+        public static ITypeUsage GetFirstTypeArgumentNode([CanBeNull] this IInvocationExpression invocationExpression)
         {
             return (invocationExpression?.InvokedExpression as IReferenceExpression)?.TypeArgumentList
                 ?.TypeArgumentNodes.FirstOrDefault();
         }
 
-        private static bool IsVerbatimString([CanBeNull]this IExpression expression)
+        private static bool IsVerbatimString([CanBeNull] this IExpression expression)
         {
             return expression?.FirstChild?.NodeType == CSharpTokenType.STRING_LITERAL_VERBATIM;
         }
@@ -281,20 +373,26 @@ namespace ReSharper.Structured.Logging.Extensions
         /// member is not a logging member. A <c>null</c> result is the plugin-wide "not a logging call" signal.
         /// </summary>
         [CanBeNull]
-        public static string GetTemplateParameterName(this ICSharpArgumentsOwner argumentsOwner, TemplateParameterNameAttributeProvider templateParameterNameAttributeProvider)
+        public static string GetTemplateParameterName(
+            this ICSharpArgumentsOwner argumentsOwner,
+            TemplateParameterNameAttributeProvider templateParameterNameAttributeProvider)
         {
             // An attribute usage resolves the invoked constructor through a dedicated reference
             var declaredElement = argumentsOwner is IAttribute attribute
-                                      ? attribute.ConstructorReference?.Resolve().DeclaredElement
-                                      : argumentsOwner.Reference?.Resolve().DeclaredElement;
+                ? attribute.ConstructorReference?.Resolve()
+                    .DeclaredElement
+                : argumentsOwner.Reference?.Resolve()
+                    .DeclaredElement;
 
             return declaredElement is ITypeMember typeMember
-                       ? templateParameterNameAttributeProvider.GetInfo(typeMember)
-                       : null;
+                ? templateParameterNameAttributeProvider.GetInfo(typeMember)
+                : null;
         }
 
         [CanBeNull]
-        private static ICSharpArgument FindTemplateArgument(this ICSharpArgumentsOwner argumentsOwner, string templateParameterName)
+        private static ICSharpArgument FindTemplateArgument(
+            this ICSharpArgumentsOwner argumentsOwner,
+            string templateParameterName)
         {
             foreach (var argument in argumentsOwner.Arguments)
             {
@@ -308,18 +406,25 @@ namespace ReSharper.Structured.Logging.Extensions
         }
 
         [CanBeNull]
-        private static IPropertyAssignment FindTemplatePropertyAssignment(this IAttribute attribute, string templateParameterName)
+        private static IPropertyAssignment FindTemplatePropertyAssignment(
+            this IAttribute attribute,
+            string templateParameterName)
         {
             // The attribute property mirrors the constructor parameter, e.g. `message` and `Message`
-            return attribute.PropertyAssignments.FirstOrDefault(
-                propertyAssignment => string.Equals(propertyAssignment.PropertyNameIdentifier?.Name, templateParameterName, StringComparison.OrdinalIgnoreCase));
+            return attribute.PropertyAssignments.FirstOrDefault(propertyAssignment => string.Equals(
+                propertyAssignment.PropertyNameIdentifier?.Name,
+                templateParameterName,
+                StringComparison.OrdinalIgnoreCase));
         }
 
-        private static void FlattenAdditiveExpression(IAdditiveExpression additiveExpression, LinkedList<ExpressionArgumentInfo> list)
+        private static void FlattenAdditiveExpression(
+            IAdditiveExpression additiveExpression,
+            LinkedList<ExpressionArgumentInfo> list)
         {
             foreach (var argumentInfo in additiveExpression.Arguments)
             {
-                if (argumentInfo is ExpressionArgumentInfo expressionArgumentInfo && expressionArgumentInfo.Expression is IAdditiveExpression additive)
+                if (argumentInfo is ExpressionArgumentInfo expressionArgumentInfo &&
+                    expressionArgumentInfo.Expression is IAdditiveExpression additive)
                 {
                     FlattenAdditiveExpression(additive, list);
 

--- a/src/ReSharper.Structured.Logging/Highlighting/DuplicateTemplatePropertyWarning.cs
+++ b/src/ReSharper.Structured.Logging/Highlighting/DuplicateTemplatePropertyWarning.cs
@@ -1,8 +1,11 @@
+using JetBrains.Annotations;
 using JetBrains.DocumentModel;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
 
 using ReSharper.Structured.Logging.Models;
+using ReSharper.Structured.Logging.Serilog.Parsing;
 using ReSharper.Structured.Logging.Settings;
 
 namespace ReSharper.Structured.Logging.Highlighting
@@ -25,12 +28,36 @@ namespace ReSharper.Structured.Logging.Highlighting
 
         public const string SeverityId = "TemplateDuplicatePropertyProblem";
 
-        private readonly DocumentRange _documentRange;
-
-        public DuplicateTemplatePropertyWarning(MessageTemplateTokenInformation tokenInformation)
+        public DuplicateTemplatePropertyWarning(
+            [NotNull] MessageTemplateTokenInformation tokenInformation,
+            [NotNull] PropertyToken namedProperty,
+            [CanBeNull] ICSharpArgument argument,
+            [NotNull] string[] usedPropertyNames)
         {
-            _documentRange = tokenInformation.DocumentRange;
+            TokenInformation = tokenInformation;
+            NamedProperty = namedProperty;
+            Argument = argument;
+            UsedPropertyNames = usedPropertyNames;
         }
+
+        [NotNull]
+        public MessageTemplateTokenInformation TokenInformation { get; }
+
+        [NotNull]
+        public PropertyToken NamedProperty { get; }
+
+        /// <summary>
+        /// The argument that fills the hole, or <c>null</c> when there is none to derive a name from,
+        /// as in an attribute template or when the values are passed as a single array.
+        /// </summary>
+        [CanBeNull]
+        public ICSharpArgument Argument { get; }
+
+        /// <summary>
+        /// Every property name the template already uses, so a fix can avoid renaming into a collision.
+        /// </summary>
+        [NotNull]
+        public string[] UsedPropertyNames { get; }
 
         public string ErrorStripeToolTip => ToolTip;
 
@@ -38,12 +65,12 @@ namespace ReSharper.Structured.Logging.Highlighting
 
         public DocumentRange CalculateRange()
         {
-            return _documentRange;
+            return TokenInformation.DocumentRange;
         }
 
         public bool IsValid()
         {
-            return _documentRange.IsValid();
+            return TokenInformation.DocumentRange.IsValid();
         }
     }
 }

--- a/src/ReSharper.Structured.Logging/Highlighting/DuplicateTemplatePropertyWarning.cs
+++ b/src/ReSharper.Structured.Logging/Highlighting/DuplicateTemplatePropertyWarning.cs
@@ -1,5 +1,4 @@
 using JetBrains.Annotations;
-using JetBrains.DocumentModel;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
@@ -22,7 +21,7 @@ namespace ReSharper.Structured.Logging.Highlighting
         CSharpLanguage.Name,
         OverlapResolve = OverlapResolveKind.WARNING,
         ToolTipFormatString = Message)]
-    public class DuplicateTemplatePropertyWarning : IHighlighting
+    public class DuplicateTemplatePropertyWarning : TemplatePropertyWarningBase, IHighlighting
     {
         private const string Message = "Duplicate properties in message template";
 
@@ -33,44 +32,12 @@ namespace ReSharper.Structured.Logging.Highlighting
             [NotNull] PropertyToken namedProperty,
             [CanBeNull] ICSharpArgument argument,
             [NotNull] string[] usedPropertyNames)
+            : base(tokenInformation, namedProperty, argument, usedPropertyNames)
         {
-            TokenInformation = tokenInformation;
-            NamedProperty = namedProperty;
-            Argument = argument;
-            UsedPropertyNames = usedPropertyNames;
         }
-
-        [NotNull]
-        public MessageTemplateTokenInformation TokenInformation { get; }
-
-        [NotNull]
-        public PropertyToken NamedProperty { get; }
-
-        /// <summary>
-        /// The argument that fills the hole, or <c>null</c> when there is none to derive a name from,
-        /// as in an attribute template or when the values are passed as a single array.
-        /// </summary>
-        [CanBeNull]
-        public ICSharpArgument Argument { get; }
-
-        /// <summary>
-        /// Every property name the template already uses, so a fix can avoid renaming into a collision.
-        /// </summary>
-        [NotNull]
-        public string[] UsedPropertyNames { get; }
 
         public string ErrorStripeToolTip => ToolTip;
 
         public string ToolTip => Message;
-
-        public DocumentRange CalculateRange()
-        {
-            return TokenInformation.DocumentRange;
-        }
-
-        public bool IsValid()
-        {
-            return TokenInformation.DocumentRange.IsValid();
-        }
     }
 }

--- a/src/ReSharper.Structured.Logging/Highlighting/ExceptionPassedAsTemplateArgumentWarning.cs
+++ b/src/ReSharper.Structured.Logging/Highlighting/ExceptionPassedAsTemplateArgumentWarning.cs
@@ -28,6 +28,11 @@ namespace ReSharper.Structured.Logging.Highlighting
 
         private const string Message = "Exception should be passed to the exception argument";
 
+        // The dedicated argument is taken, so the advice above does not apply: the only way out is to stop
+        // passing this exception as a property
+        private const string ExceptionArgumentOccupiedMessage =
+            "Exception should not be passed as a template argument, the exception argument is already used";
+
         private readonly DocumentRange _documentRange;
 
         public ExceptionPassedAsTemplateArgumentWarning(
@@ -74,7 +79,7 @@ namespace ReSharper.Structured.Logging.Highlighting
 
         public string ErrorStripeToolTip => ToolTip;
 
-        public string ToolTip => Message;
+        public string ToolTip => ExceptionArgumentOccupied ? ExceptionArgumentOccupiedMessage : Message;
 
         public DocumentRange CalculateRange()
         {

--- a/src/ReSharper.Structured.Logging/Highlighting/ExceptionPassedAsTemplateArgumentWarning.cs
+++ b/src/ReSharper.Structured.Logging/Highlighting/ExceptionPassedAsTemplateArgumentWarning.cs
@@ -32,19 +32,32 @@ namespace ReSharper.Structured.Logging.Highlighting
 
         public ExceptionPassedAsTemplateArgumentWarning(
             [NotNull] ICSharpArgument exceptionArgument,
+            [NotNull] ICSharpArgument templateArgument,
             [NotNull] IInvocationExpression invocationExpression,
             [CanBeNull] MessageTemplateTokenInformation tokenInformation,
-            [CanBeNull] PropertyToken namedProperty)
+            [CanBeNull] PropertyToken namedProperty,
+            bool exceptionArgumentOccupied)
         {
             ExceptionArgument = exceptionArgument;
+            TemplateArgument = templateArgument;
             InvocationExpression = invocationExpression;
             TokenInformation = tokenInformation;
             NamedProperty = namedProperty;
+            ExceptionArgumentOccupied = exceptionArgumentOccupied;
             _documentRange = exceptionArgument.GetDocumentRange();
         }
 
+        /// <summary>
+        /// Whether another exception already fills the dedicated exception argument. The message is still wrong,
+        /// but moving this one there would pass two exceptions, so no fix is offered.
+        /// </summary>
+        public bool ExceptionArgumentOccupied { get; }
+
         [NotNull]
         public ICSharpArgument ExceptionArgument { get; }
+
+        [NotNull]
+        public ICSharpArgument TemplateArgument { get; }
 
         [NotNull]
         public IInvocationExpression InvocationExpression { get; }

--- a/src/ReSharper.Structured.Logging/Highlighting/ExceptionPassedAsTemplateArgumentWarning.cs
+++ b/src/ReSharper.Structured.Logging/Highlighting/ExceptionPassedAsTemplateArgumentWarning.cs
@@ -1,7 +1,11 @@
+using JetBrains.Annotations;
 using JetBrains.DocumentModel;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
 
+using ReSharper.Structured.Logging.Models;
+using ReSharper.Structured.Logging.Serilog.Parsing;
 using ReSharper.Structured.Logging.Settings;
 
 namespace ReSharper.Structured.Logging.Highlighting
@@ -26,10 +30,34 @@ namespace ReSharper.Structured.Logging.Highlighting
 
         private readonly DocumentRange _documentRange;
 
-        public ExceptionPassedAsTemplateArgumentWarning(DocumentRange documentRange)
+        public ExceptionPassedAsTemplateArgumentWarning(
+            [NotNull] ICSharpArgument exceptionArgument,
+            [NotNull] IInvocationExpression invocationExpression,
+            [CanBeNull] MessageTemplateTokenInformation tokenInformation,
+            [CanBeNull] PropertyToken namedProperty)
         {
-            _documentRange = documentRange;
+            ExceptionArgument = exceptionArgument;
+            InvocationExpression = invocationExpression;
+            TokenInformation = tokenInformation;
+            NamedProperty = namedProperty;
+            _documentRange = exceptionArgument.GetDocumentRange();
         }
+
+        [NotNull]
+        public ICSharpArgument ExceptionArgument { get; }
+
+        [NotNull]
+        public IInvocationExpression InvocationExpression { get; }
+
+        /// <summary>
+        /// The template hole the exception is bound to, or <c>null</c> when the template is not a literal
+        /// the fix can rewrite. The fix then only moves the argument.
+        /// </summary>
+        [CanBeNull]
+        public MessageTemplateTokenInformation TokenInformation { get; }
+
+        [CanBeNull]
+        public PropertyToken NamedProperty { get; }
 
         public string ErrorStripeToolTip => ToolTip;
 

--- a/src/ReSharper.Structured.Logging/Highlighting/PositionalPropertyUsedWarning.cs
+++ b/src/ReSharper.Structured.Logging/Highlighting/PositionalPropertyUsedWarning.cs
@@ -1,8 +1,11 @@
+using JetBrains.Annotations;
 using JetBrains.DocumentModel;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
 
 using ReSharper.Structured.Logging.Models;
+using ReSharper.Structured.Logging.Serilog.Parsing;
 using ReSharper.Structured.Logging.Settings;
 
 namespace ReSharper.Structured.Logging.Highlighting
@@ -21,16 +24,40 @@ namespace ReSharper.Structured.Logging.Highlighting
         ToolTipFormatString = Message)]
     public class PositionalPropertyUsedWarning : IHighlighting
     {
-        private readonly MessageTemplateTokenInformation _tokenInformation;
-
         private const string Message = "Prefer named properties instead of positional ones";
 
         public const string SeverityId = "PositionalPropertyUsedProblem";
 
-        public PositionalPropertyUsedWarning(MessageTemplateTokenInformation tokenInformation)
+        public PositionalPropertyUsedWarning(
+            [NotNull] MessageTemplateTokenInformation tokenInformation,
+            [NotNull] PropertyToken namedProperty,
+            [CanBeNull] ICSharpArgument argument,
+            [NotNull] string[] usedPropertyNames)
         {
-            _tokenInformation = tokenInformation;
+            TokenInformation = tokenInformation;
+            NamedProperty = namedProperty;
+            Argument = argument;
+            UsedPropertyNames = usedPropertyNames;
         }
+
+        [NotNull]
+        public MessageTemplateTokenInformation TokenInformation { get; }
+
+        [NotNull]
+        public PropertyToken NamedProperty { get; }
+
+        /// <summary>
+        /// The argument that fills the hole, or <c>null</c> when there is none to derive a name from,
+        /// as in an attribute template or when the values are passed as a single array.
+        /// </summary>
+        [CanBeNull]
+        public ICSharpArgument Argument { get; }
+
+        /// <summary>
+        /// Every property name the template already uses, so a fix can avoid renaming into a collision.
+        /// </summary>
+        [NotNull]
+        public string[] UsedPropertyNames { get; }
 
         public string ErrorStripeToolTip => ToolTip;
 
@@ -38,12 +65,12 @@ namespace ReSharper.Structured.Logging.Highlighting
 
         public DocumentRange CalculateRange()
         {
-            return _tokenInformation.DocumentRange;
+            return TokenInformation.DocumentRange;
         }
 
         public bool IsValid()
         {
-            return _tokenInformation.DocumentRange.IsValid();
+            return TokenInformation.DocumentRange.IsValid();
         }
     }
 }

--- a/src/ReSharper.Structured.Logging/Highlighting/PositionalPropertyUsedWarning.cs
+++ b/src/ReSharper.Structured.Logging/Highlighting/PositionalPropertyUsedWarning.cs
@@ -1,5 +1,4 @@
 using JetBrains.Annotations;
-using JetBrains.DocumentModel;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
@@ -22,7 +21,7 @@ namespace ReSharper.Structured.Logging.Highlighting
         CSharpLanguage.Name,
         OverlapResolve = OverlapResolveKind.WARNING,
         ToolTipFormatString = Message)]
-    public class PositionalPropertyUsedWarning : IHighlighting
+    public class PositionalPropertyUsedWarning : TemplatePropertyWarningBase, IHighlighting
     {
         private const string Message = "Prefer named properties instead of positional ones";
 
@@ -33,44 +32,12 @@ namespace ReSharper.Structured.Logging.Highlighting
             [NotNull] PropertyToken namedProperty,
             [CanBeNull] ICSharpArgument argument,
             [NotNull] string[] usedPropertyNames)
+            : base(tokenInformation, namedProperty, argument, usedPropertyNames)
         {
-            TokenInformation = tokenInformation;
-            NamedProperty = namedProperty;
-            Argument = argument;
-            UsedPropertyNames = usedPropertyNames;
         }
-
-        [NotNull]
-        public MessageTemplateTokenInformation TokenInformation { get; }
-
-        [NotNull]
-        public PropertyToken NamedProperty { get; }
-
-        /// <summary>
-        /// The argument that fills the hole, or <c>null</c> when there is none to derive a name from,
-        /// as in an attribute template or when the values are passed as a single array.
-        /// </summary>
-        [CanBeNull]
-        public ICSharpArgument Argument { get; }
-
-        /// <summary>
-        /// Every property name the template already uses, so a fix can avoid renaming into a collision.
-        /// </summary>
-        [NotNull]
-        public string[] UsedPropertyNames { get; }
 
         public string ErrorStripeToolTip => ToolTip;
 
         public string ToolTip => Message;
-
-        public DocumentRange CalculateRange()
-        {
-            return TokenInformation.DocumentRange;
-        }
-
-        public bool IsValid()
-        {
-            return TokenInformation.DocumentRange.IsValid();
-        }
     }
 }

--- a/src/ReSharper.Structured.Logging/Highlighting/TemplatePropertyWarningBase.cs
+++ b/src/ReSharper.Structured.Logging/Highlighting/TemplatePropertyWarningBase.cs
@@ -1,0 +1,56 @@
+using JetBrains.Annotations;
+using JetBrains.DocumentModel;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+
+using ReSharper.Structured.Logging.Models;
+using ReSharper.Structured.Logging.Serilog.Parsing;
+
+namespace ReSharper.Structured.Logging.Highlighting
+{
+    /// <summary>
+    /// The payload shared by the template property warnings a rename fix can act on.
+    /// </summary>
+    public abstract class TemplatePropertyWarningBase
+    {
+        protected TemplatePropertyWarningBase(
+            [NotNull] MessageTemplateTokenInformation tokenInformation,
+            [NotNull] PropertyToken namedProperty,
+            [CanBeNull] ICSharpArgument argument,
+            [NotNull] string[] usedPropertyNames)
+        {
+            TokenInformation = tokenInformation;
+            NamedProperty = namedProperty;
+            Argument = argument;
+            UsedPropertyNames = usedPropertyNames;
+        }
+
+        [NotNull]
+        public MessageTemplateTokenInformation TokenInformation { get; }
+
+        [NotNull]
+        public PropertyToken NamedProperty { get; }
+
+        /// <summary>
+        /// The argument that fills the hole, or <c>null</c> when there is none to derive a name from,
+        /// as in an attribute template or when the values are passed as a single array.
+        /// </summary>
+        [CanBeNull]
+        public ICSharpArgument Argument { get; }
+
+        /// <summary>
+        /// Every property name the template already uses, so a fix can avoid renaming into a collision.
+        /// </summary>
+        [NotNull]
+        public string[] UsedPropertyNames { get; }
+
+        public DocumentRange CalculateRange()
+        {
+            return TokenInformation.DocumentRange;
+        }
+
+        public bool IsValid()
+        {
+            return TokenInformation.DocumentRange.IsValid();
+        }
+    }
+}

--- a/src/ReSharper.Structured.Logging/QuickFixes/MoveExceptionArgumentFix.cs
+++ b/src/ReSharper.Structured.Logging/QuickFixes/MoveExceptionArgumentFix.cs
@@ -1,0 +1,113 @@
+using System;
+
+using JetBrains.Annotations;
+using JetBrains.Application.Progress;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.QuickFixes;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Tree;
+using JetBrains.ReSharper.Psi.Util;
+using JetBrains.ReSharper.Resources.Shell;
+using JetBrains.TextControl;
+using JetBrains.Util;
+
+using ReSharper.Structured.Logging.Highlighting;
+using ReSharper.Structured.Logging.Models;
+using ReSharper.Structured.Logging.Serilog.Parsing;
+
+namespace ReSharper.Structured.Logging.QuickFixes
+{
+    [QuickFix]
+    public class MoveExceptionArgumentFix : QuickFixBase
+    {
+        private readonly ICSharpArgument _exceptionArgument;
+
+        private readonly bool _exceptionArgumentOccupied;
+
+        private readonly IInvocationExpression _invocationExpression;
+
+        [CanBeNull] private readonly PropertyToken _namedProperty;
+
+        private readonly ICSharpArgument _templateArgument;
+
+        [CanBeNull] private readonly MessageTemplateTokenInformation _tokenInformation;
+
+        public MoveExceptionArgumentFix([NotNull] ExceptionPassedAsTemplateArgumentWarning error)
+        {
+            _exceptionArgument = error.ExceptionArgument;
+            _templateArgument = error.TemplateArgument;
+            _invocationExpression = error.InvocationExpression;
+            _tokenInformation = error.TokenInformation;
+            _namedProperty = error.NamedProperty;
+            _exceptionArgumentOccupied = error.ExceptionArgumentOccupied;
+        }
+
+        public override string Text => "Pass exception to the exception argument";
+
+        public override bool IsAvailable(IUserDataHolder cache)
+        {
+            // Moving the exception when another one already fills the dedicated argument
+            // would pass two exceptions, which does not compile
+            return !_exceptionArgumentOccupied
+                   && _invocationExpression.IsValid()
+                   && _exceptionArgument.IsValid()
+                   && _templateArgument.IsValid();
+        }
+
+        protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
+        {
+            using (WriteLockCookie.Create())
+            {
+                var factory = CSharpElementFactory.GetInstance(_invocationExpression, false);
+
+                // The hole the exception filled is only known when the template is a literal the fix can rewrite,
+                // otherwise the argument is moved and the message is left alone
+                if (_tokenInformation?.StringLiteral != null && _namedProperty != null)
+                {
+                    var literalExpression = _tokenInformation.StringLiteral.Expression;
+                    var templateText = RemoveProperty(
+                        literalExpression.GetUnquotedText(),
+                        _tokenInformation.RelativeStartIndex,
+                        _namedProperty.Length);
+
+                    ModificationUtil.ReplaceChild(literalExpression, factory.CreateExpression($"\"{templateText}\""));
+                }
+
+                var exceptionExpression = _exceptionArgument.Value;
+                if (exceptionExpression != null)
+                {
+                    _invocationExpression.AddArgumentBefore(
+                        factory.CreateArgument(ParameterKind.VALUE, exceptionExpression),
+                        _templateArgument);
+                }
+
+                _invocationExpression.RemoveArgument(_exceptionArgument);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Removes the hole from the template and collapses the separator it leaves behind, so that
+        /// "exceeded {Exception}" becomes "exceeded" rather than "exceeded ".
+        /// </summary>
+        private static string RemoveProperty([NotNull] string templateText, int startIndex, int length)
+        {
+            var text = templateText.Remove(startIndex, length);
+            if (startIndex == 0 || templateText[startIndex - 1] != ' ')
+            {
+                return text;
+            }
+
+            // A hole between two words leaves a double space, a trailing hole leaves a trailing space
+            if (startIndex == text.Length || text[startIndex] == ' ')
+            {
+                return text.Remove(startIndex - 1, 1);
+            }
+
+            return text;
+        }
+    }
+}

--- a/src/ReSharper.Structured.Logging/QuickFixes/RenameTemplatePropertyFixBase.cs
+++ b/src/ReSharper.Structured.Logging/QuickFixes/RenameTemplatePropertyFixBase.cs
@@ -37,15 +37,19 @@ namespace ReSharper.Structured.Logging.QuickFixes
 
         private bool _suggestedNameCalculated;
 
+        // A quick fix binds to a highlighting by the type of its constructor parameter, so each warning
+        // needs its own overload even though they carry the same payload
         protected RenameTemplatePropertyFixBase([NotNull] PositionalPropertyUsedWarning error)
+            : this((TemplatePropertyWarningBase)error)
         {
-            _tokenInformation = error.TokenInformation;
-            _namedProperty = error.NamedProperty;
-            _argument = error.Argument;
-            _usedPropertyNames = error.UsedPropertyNames;
         }
 
         protected RenameTemplatePropertyFixBase([NotNull] DuplicateTemplatePropertyWarning error)
+            : this((TemplatePropertyWarningBase)error)
+        {
+        }
+
+        private RenameTemplatePropertyFixBase([NotNull] TemplatePropertyWarningBase error)
         {
             _tokenInformation = error.TokenInformation;
             _namedProperty = error.NamedProperty;

--- a/src/ReSharper.Structured.Logging/QuickFixes/RenameTemplatePropertyFixBase.cs
+++ b/src/ReSharper.Structured.Logging/QuickFixes/RenameTemplatePropertyFixBase.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Linq;
+
+using JetBrains.Annotations;
+using JetBrains.Application.Progress;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.QuickFixes;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Tree;
+using JetBrains.ReSharper.Psi.Util;
+using JetBrains.ReSharper.Resources.Shell;
+using JetBrains.TextControl;
+using JetBrains.Util;
+
+using ReSharper.Structured.Logging.Highlighting;
+using ReSharper.Structured.Logging.Models;
+using ReSharper.Structured.Logging.Serilog.Parsing;
+using ReSharper.Structured.Logging.Services;
+
+namespace ReSharper.Structured.Logging.QuickFixes
+{
+    /// <summary>
+    /// Renames a template hole to a name derived from the argument that fills it.
+    /// </summary>
+    public abstract class RenameTemplatePropertyFixBase : QuickFixBase
+    {
+        [CanBeNull] private readonly ICSharpArgument _argument;
+
+        private readonly PropertyToken _namedProperty;
+
+        private readonly MessageTemplateTokenInformation _tokenInformation;
+
+        private readonly string[] _usedPropertyNames;
+
+        [CanBeNull] private string _suggestedName;
+
+        private bool _suggestedNameCalculated;
+
+        protected RenameTemplatePropertyFixBase([NotNull] PositionalPropertyUsedWarning error)
+        {
+            _tokenInformation = error.TokenInformation;
+            _namedProperty = error.NamedProperty;
+            _argument = error.Argument;
+            _usedPropertyNames = error.UsedPropertyNames;
+        }
+
+        protected RenameTemplatePropertyFixBase([NotNull] DuplicateTemplatePropertyWarning error)
+        {
+            _tokenInformation = error.TokenInformation;
+            _namedProperty = error.NamedProperty;
+            _argument = error.Argument;
+            _usedPropertyNames = error.UsedPropertyNames;
+        }
+
+        public override string Text => $"Rename property to '{SuggestedName}'";
+
+        [CanBeNull]
+        private string SuggestedName
+        {
+            get
+            {
+                if (!_suggestedNameCalculated)
+                {
+                    _suggestedName = CalculateSuggestedName();
+                    _suggestedNameCalculated = true;
+                }
+
+                return _suggestedName;
+            }
+        }
+
+        public override bool IsAvailable(IUserDataHolder cache)
+        {
+            return _tokenInformation.DocumentRange.IsValid()
+                   && _tokenInformation.StringLiteral != null
+                   && SuggestedName != null;
+        }
+
+        /// <summary>
+        /// Returns the name this fix renames the hole to, or <c>null</c> when it has nothing to offer.
+        /// </summary>
+        [CanBeNull]
+        protected abstract string GetSuggestedName([CanBeNull] string leafName, [CanBeNull] string qualifiedName);
+
+        /// <summary>
+        /// Appends a counter until the name no longer collides with another hole of the same template.
+        /// </summary>
+        [NotNull]
+        protected string MakeUnique([NotNull] string name)
+        {
+            var candidate = name;
+            var counter = 2;
+            while (_usedPropertyNames.Contains(candidate, StringComparer.Ordinal))
+            {
+                candidate = name + counter++;
+            }
+
+            return candidate;
+        }
+
+        protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
+        {
+            var suggestedName = SuggestedName;
+            if (suggestedName == null)
+            {
+                return null;
+            }
+
+            using (WriteLockCookie.Create())
+            {
+                var literalExpression = _tokenInformation.StringLiteral.Expression;
+                var factory = CSharpElementFactory.GetInstance(literalExpression, false);
+
+                // A hole is the brace, an optional destructuring hint, the name, and then any alignment
+                // and format, so replacing exactly the name keeps the rest of the hole intact
+                var startIndex = _tokenInformation.RelativeStartIndex
+                                 + (_namedProperty.Destructuring == Destructuring.Default ? 1 : 2);
+                var templateText = literalExpression.GetUnquotedText()
+                    .Remove(startIndex, _namedProperty.PropertyName.Length)
+                    .Insert(startIndex, suggestedName);
+
+                ModificationUtil.ReplaceChild(literalExpression, factory.CreateExpression($"\"{templateText}\""));
+            }
+
+            return null;
+        }
+
+        [CanBeNull]
+        private string CalculateSuggestedName()
+        {
+            var (leafName, qualifiedName) = TemplatePropertyNameSuggestion.GetSuggestedNames(_argument?.Value);
+            var suggestedName = GetSuggestedName(leafName, qualifiedName);
+
+            return suggestedName == null ? null : MakeUnique(suggestedName);
+        }
+    }
+}

--- a/src/ReSharper.Structured.Logging/QuickFixes/RenameTemplatePropertyFromArgumentFix.cs
+++ b/src/ReSharper.Structured.Logging/QuickFixes/RenameTemplatePropertyFromArgumentFix.cs
@@ -1,0 +1,44 @@
+using JetBrains.Annotations;
+using JetBrains.ReSharper.Feature.Services.QuickFixes;
+
+using ReSharper.Structured.Logging.Highlighting;
+
+namespace ReSharper.Structured.Logging.QuickFixes
+{
+    /// <summary>
+    /// Renames the hole to the short name of the argument that fills it, so a hole filled by
+    /// <c>order.Customer.Name</c> becomes <c>{Name}</c>.
+    /// </summary>
+    [QuickFix]
+    public class RenameTemplatePropertyFromArgumentFix : RenameTemplatePropertyFixBase
+    {
+        private readonly bool _hasFallbackName;
+
+        private readonly string _propertyName;
+
+        public RenameTemplatePropertyFromArgumentFix([NotNull] PositionalPropertyUsedWarning error)
+            : base(error)
+        {
+            _propertyName = error.NamedProperty.PropertyName;
+        }
+
+        public RenameTemplatePropertyFromArgumentFix([NotNull] DuplicateTemplatePropertyWarning error)
+            : base(error)
+        {
+            // A duplicate already carries a name, so it can always fall back to a numbered variant of itself
+            _propertyName = error.NamedProperty.PropertyName;
+            _hasFallbackName = true;
+        }
+
+        protected override string GetSuggestedName(string leafName, string qualifiedName)
+        {
+            if (leafName != null)
+            {
+                return leafName;
+            }
+
+            // A positional hole has no name worth keeping, so with no argument there is nothing to suggest
+            return _hasFallbackName ? _propertyName : null;
+        }
+    }
+}

--- a/src/ReSharper.Structured.Logging/QuickFixes/RenameTemplatePropertyToQualifiedNameFix.cs
+++ b/src/ReSharper.Structured.Logging/QuickFixes/RenameTemplatePropertyToQualifiedNameFix.cs
@@ -1,0 +1,31 @@
+using JetBrains.Annotations;
+using JetBrains.ReSharper.Feature.Services.QuickFixes;
+
+using ReSharper.Structured.Logging.Highlighting;
+
+namespace ReSharper.Structured.Logging.QuickFixes
+{
+    /// <summary>
+    /// Renames the hole to the qualified name of the argument that fills it, so a hole filled by
+    /// <c>order.Customer.Name</c> becomes <c>{CustomerName}</c>. Offered next to
+    /// <see cref="RenameTemplatePropertyFromArgumentFix"/> only when the two names differ.
+    /// </summary>
+    [QuickFix]
+    public class RenameTemplatePropertyToQualifiedNameFix : RenameTemplatePropertyFixBase
+    {
+        public RenameTemplatePropertyToQualifiedNameFix([NotNull] PositionalPropertyUsedWarning error)
+            : base(error)
+        {
+        }
+
+        public RenameTemplatePropertyToQualifiedNameFix([NotNull] DuplicateTemplatePropertyWarning error)
+            : base(error)
+        {
+        }
+
+        protected override string GetSuggestedName(string leafName, string qualifiedName)
+        {
+            return qualifiedName;
+        }
+    }
+}

--- a/src/ReSharper.Structured.Logging/Utils/TemplatePropertyNameSuggestion.cs
+++ b/src/ReSharper.Structured.Logging/Utils/TemplatePropertyNameSuggestion.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Linq;
+
+using JetBrains.Annotations;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Naming;
+using JetBrains.ReSharper.Psi.Naming.Elements;
+using JetBrains.ReSharper.Psi.Naming.Extentions;
+using JetBrains.ReSharper.Psi.Naming.Impl;
+using JetBrains.ReSharper.Psi.Naming.Settings;
+using JetBrains.ReSharper.Psi.Tree;
+
+namespace ReSharper.Structured.Logging.Services
+{
+    /// <summary>
+    /// Derives template property names from the expression that fills the hole, so that
+    /// <c>order.Customer.Name</c> can suggest both <c>Name</c> and <c>CustomerName</c>.
+    /// </summary>
+    public static class TemplatePropertyNameSuggestion
+    {
+        /// <summary>
+        /// Returns the short name built from the expression and, when the naming engine offers a longer
+        /// candidate, the qualified one. Both are already converted to the configured naming style.
+        /// Either can be <c>null</c> when nothing can be derived, which is the case for an attribute
+        /// template, where no expression fills the hole.
+        /// </summary>
+        public static (string LeafName, string QualifiedName) GetSuggestedNames([CanBeNull] ICSharpExpression expression)
+        {
+            var sourceFile = expression?.GetSourceFile();
+            if (sourceFile == null)
+            {
+                return (null, null);
+            }
+
+            var namingManager = expression.GetPsiServices().Naming;
+            var namingLanguageService = NamingManager.GetNamingLanguageService(expression.Language);
+            var settingsStore = expression.GetSettingsStoreWithEditorConfig();
+            var namesCollection = namingManager.Suggestion.CreateEmptyCollection(
+                PluralityKinds.Unknown,
+                expression.Language,
+                longerNamesFirst: true,
+                sourceFile);
+
+            var entryOptions = new EntryOptions(
+                PluralityKinds.Unknown,
+                SubrootPolicy.Decompose,
+                PredefinedPrefixPolicy.Remove);
+            foreach (var suggestRoot in namingLanguageService.SuggestRoots(
+                         expression,
+                         useExpectedTypes: false,
+                         namesCollection.PolicyProvider))
+            {
+                namesCollection.Add(suggestRoot, entryOptions);
+            }
+
+            var defaultRule = namingManager.Policy.GetDefaultRule(
+                sourceFile,
+                expression.Language,
+                settingsStore,
+                NamedElementKinds.Property,
+                ElementKindOfElementType.PROPERTY);
+
+            var names = namesCollection.Prepare(defaultRule, ScopeKind.Common, new SuggestionOptions())
+                .AllNames()
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Select(n => PropertyNameProvider.GetSuggestedName(n, settingsStore))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+
+            if (names.Length == 0)
+            {
+                return (null, null);
+            }
+
+            // The engine is asked for longer names first, so the shortest candidate is the leaf name
+            // and the longest is the qualified one
+            var leafName = names.OrderBy(n => n.Length).First();
+            var qualifiedName = names.OrderByDescending(n => n.Length).First();
+
+            return (leafName, string.Equals(leafName, qualifiedName, StringComparison.Ordinal) ? null : qualifiedName);
+        }
+    }
+}

--- a/test/data/Analyzers/ComplexTypeDestructure/SerilogArrayArgumentsWithoutDestructure.cs
+++ b/test/data/Analyzers/ComplexTypeDestructure/SerilogArrayArgumentsWithoutDestructure.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            Log.Logger.Information("{First}", new object[] { new Random() });
+        }
+    }
+}

--- a/test/data/Analyzers/ComplexTypeDestructure/SerilogArrayArgumentsWithoutDestructure.cs.gold
+++ b/test/data/Analyzers/ComplexTypeDestructure/SerilogArrayArgumentsWithoutDestructure.cs.gold
@@ -7,10 +7,9 @@ namespace ConsoleApp
     {
         public static void Main()
         {
-            Log.Logger.Information(new Exception(), "{One} {OtherException}", 1, |new Exception()|(0));
+            Log.Logger.Information("{First}", new object[] { new Random() });
         }
     }
 }
 
 ---------------------------------------------------------
-(0): ReSharper Warning: Exception should be passed to the exception argument

--- a/test/data/Analyzers/ComplexTypeDestructure/SerilogNamedArgumentsWithoutDestructure.cs
+++ b/test/data/Analyzers/ComplexTypeDestructure/SerilogNamedArgumentsWithoutDestructure.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            Log.Logger.Information(propertyValue0: new Random(), messageTemplate: "{First} {Second}", propertyValue1: 1);
+        }
+    }
+}

--- a/test/data/Analyzers/ComplexTypeDestructure/SerilogNamedArgumentsWithoutDestructure.cs.gold
+++ b/test/data/Analyzers/ComplexTypeDestructure/SerilogNamedArgumentsWithoutDestructure.cs.gold
@@ -1,0 +1,16 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            Log.Logger.Information(propertyValue0: new Random(), messageTemplate: "|{First}|(0) {Second}", propertyValue1: 1);
+        }
+    }
+}
+
+---------------------------------------------------------
+(0): ReSharper Warning: Complex objects with default ToString() implementation probably need to be destructured

--- a/test/data/Analyzers/CorrectExceptionPassing/SerilogExceptionInArrayArguments.cs
+++ b/test/data/Analyzers/CorrectExceptionPassing/SerilogExceptionInArrayArguments.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            Log.Logger.Information("{One} {Two}", new object[] { 1, new Exception() });
+        }
+    }
+}

--- a/test/data/Analyzers/CorrectExceptionPassing/SerilogExceptionInArrayArguments.cs.gold
+++ b/test/data/Analyzers/CorrectExceptionPassing/SerilogExceptionInArrayArguments.cs.gold
@@ -7,10 +7,9 @@ namespace ConsoleApp
     {
         public static void Main()
         {
-            Log.Logger.Information(new Exception(), "{One} {OtherException}", 1, |new Exception()|(0));
+            Log.Logger.Information("{One} {Two}", new object[] { 1, new Exception() });
         }
     }
 }
 
 ---------------------------------------------------------
-(0): ReSharper Warning: Exception should be passed to the exception argument

--- a/test/data/Analyzers/CorrectExceptionPassing/SerilogMultipleExceptionPassing.cs.gold
+++ b/test/data/Analyzers/CorrectExceptionPassing/SerilogMultipleExceptionPassing.cs.gold
@@ -13,4 +13,4 @@ namespace ConsoleApp
 }
 
 ---------------------------------------------------------
-(0): ReSharper Warning: Exception should be passed to the exception argument
+(0): ReSharper Warning: Exception should not be passed as a template argument, the exception argument is already used

--- a/test/data/Analyzers/CorrectExceptionPassing/SerilogNamedArgumentException.cs
+++ b/test/data/Analyzers/CorrectExceptionPassing/SerilogNamedArgumentException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            Log.Logger.Information(messageTemplate: "{One}", exception: new Exception());
+        }
+    }
+}

--- a/test/data/Analyzers/CorrectExceptionPassing/SerilogNamedArgumentException.cs.gold
+++ b/test/data/Analyzers/CorrectExceptionPassing/SerilogNamedArgumentException.cs.gold
@@ -7,10 +7,9 @@ namespace ConsoleApp
     {
         public static void Main()
         {
-            Log.Logger.Information(new Exception(), "{One} {OtherException}", 1, |new Exception()|(0));
+            Log.Logger.Information(messageTemplate: "{One}", exception: new Exception());
         }
     }
 }
 
 ---------------------------------------------------------
-(0): ReSharper Warning: Exception should be passed to the exception argument

--- a/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogDynamicTemplate.cs
+++ b/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogDynamicTemplate.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main(Exception exception)
+        {
+            Log.Logger.Error($"Failed at {DateTime.Now}", {caret}exception);
+        }
+    }
+}

--- a/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogDynamicTemplate.cs.gold
+++ b/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogDynamicTemplate.cs.gold
@@ -1,0 +1,13 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main(Exception exception)
+        {
+            Log.Logger.Error(exception, $"Failed at {DateTime.Now}"{caret});
+        }
+    }
+}

--- a/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionArgumentOccupiedByNewExceptionNotAvailable.cs
+++ b/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionArgumentOccupiedByNewExceptionNotAvailable.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main(Exception exception)
+        {
+            Log.Logger.Error(exception, "Disk quota {Quota} MB exceeded {Other}", 100, {caret}new Exception("second"));
+        }
+    }
+}

--- a/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionArgumentOccupiedByNewExceptionNotAvailable.cs.gold
+++ b/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionArgumentOccupiedByNewExceptionNotAvailable.cs.gold
@@ -5,9 +5,9 @@ namespace ConsoleApp
 {
     public static class Program
     {
-        public static void Main(Exception exception, Exception other, int quota)
+        public static void Main(Exception exception)
         {
-            Log.Logger.Error(other, "Disk quota {Quota} MB exceeded {Exception}", quota, |exception|(0));
+            Log.Logger.Error(exception, "Disk quota {Quota} MB exceeded {Other}", 100, |new Exception("second")|(0));
         }
     }
 }

--- a/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionArgumentOccupiedNotAvailable.cs
+++ b/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionArgumentOccupiedNotAvailable.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main(Exception exception, Exception other, int quota)
+        {
+            Log.Logger.Error(other, "Disk quota {Quota} MB exceeded {Exception}", quota, {caret}exception);
+        }
+    }
+}

--- a/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionArgumentOccupiedNotAvailable.cs.gold
+++ b/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionArgumentOccupiedNotAvailable.cs.gold
@@ -1,0 +1,17 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main(Exception exception, Exception other, int quota)
+        {
+            Log.Logger.Error(other, "Disk quota {Quota} MB exceeded {Exception}", quota, |exception|(0));
+        }
+    }
+}
+
+------------------------------------------------
+0: Exception should be passed to the exception argument
+NO QUICKFIXES

--- a/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionAvailable.cs
+++ b/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionAvailable.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main(Exception exception, int quota)
+        {
+            Log.Logger.Error("Disk quota {Quota} MB exceeded {Exception}", quota, {caret}exception);
+        }
+    }
+}

--- a/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionAvailable.cs.gold
+++ b/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionAvailable.cs.gold
@@ -1,0 +1,18 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main(Exception exception, int quota)
+        {
+            Log.Logger.Error("Disk quota {Quota} MB exceeded {Exception}", quota, |exception|(0));
+        }
+    }
+}
+
+------------------------------------------------
+0: Exception should be passed to the exception argument
+QUICKFIXES:
+Pass exception to the exception argument

--- a/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionPropertyInTheMiddle.cs
+++ b/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionPropertyInTheMiddle.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main(Exception exception, int quota)
+        {
+            Log.Logger.Error("Disk quota {Exception} MB exceeded {Quota}", {caret}exception, quota);
+        }
+    }
+}

--- a/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionPropertyInTheMiddle.cs.gold
+++ b/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogExceptionPropertyInTheMiddle.cs.gold
@@ -1,0 +1,13 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main(Exception exception, int quota)
+        {
+            Log.Logger.Error(exception, "Disk quota MB exceeded {Quota}"{caret}, quota);
+        }
+    }
+}

--- a/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogTrailingExceptionProperty.cs
+++ b/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogTrailingExceptionProperty.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main(Exception exception, int quota)
+        {
+            Log.Logger.Error("Disk quota {Quota} MB exceeded {Exception}", quota, {caret}exception);
+        }
+    }
+}

--- a/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogTrailingExceptionProperty.cs.gold
+++ b/test/data/QuickFixes/MoveExceptionArgumentFix/TestSerilogTrailingExceptionProperty.cs.gold
@@ -1,0 +1,13 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main(Exception exception, int quota)
+        {
+            Log.Logger.Error(exception, "Disk quota {Quota} MB exceeded", quota{caret});
+        }
+    }
+}

--- a/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestLoggerMessageAttributeDuplicateProperty.cs
+++ b/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestLoggerMessageAttributeDuplicateProperty.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "{Host} is not equal to {Ho{caret}st}")]
+        public static partial void HostMismatch(ILogger logger, string host, string otherHost);
+    }
+}

--- a/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestLoggerMessageAttributeDuplicateProperty.cs.gold
+++ b/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestLoggerMessageAttributeDuplicateProperty.cs.gold
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleApp
+{
+    public static partial class LogMessages
+    {
+        [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "{Host} is not equal to {Ho{caret}st2}")]
+        public static partial void HostMismatch(ILogger logger, string host, string otherHost);
+    }
+}

--- a/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestSerilogLeafNameOffered.cs
+++ b/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestSerilogLeafNameOffered.cs
@@ -1,0 +1,17 @@
+﻿using Serilog;
+
+namespace ConsoleApp
+{
+    public class Order
+    {
+        public int Id { get; set; }
+    }
+
+    public static class Program
+    {
+        public static void Main(Order order)
+        {
+            Log.Logger.Information("Order {0{caret}} processed", order.Id);
+        }
+    }
+}

--- a/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestSerilogLeafNameOffered.cs.gold
+++ b/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestSerilogLeafNameOffered.cs.gold
@@ -1,0 +1,22 @@
+﻿using Serilog;
+
+namespace ConsoleApp
+{
+    public class Order
+    {
+        public int Id { get; set; }
+    }
+
+    public static class Program
+    {
+        public static void Main(Order order)
+        {
+            Log.Logger.Information("Order |{0}|(0) processed", order.Id);
+        }
+    }
+}
+
+------------------------------------------------
+0: Prefer named properties instead of positional ones
+QUICKFIXES:
+Rename property to 'Id'

--- a/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestSerilogPositionalProperty.cs
+++ b/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestSerilogPositionalProperty.cs
@@ -1,0 +1,17 @@
+﻿using Serilog;
+
+namespace ConsoleApp
+{
+    public class Order
+    {
+        public int Id { get; set; }
+    }
+
+    public static class Program
+    {
+        public static void Main(Order order)
+        {
+            Log.Logger.Information("Order {0{caret}} processed", order.Id);
+        }
+    }
+}

--- a/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestSerilogPositionalProperty.cs.gold
+++ b/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestSerilogPositionalProperty.cs.gold
@@ -1,0 +1,17 @@
+﻿using Serilog;
+
+namespace ConsoleApp
+{
+    public class Order
+    {
+        public int Id { get; set; }
+    }
+
+    public static class Program
+    {
+        public static void Main(Order order)
+        {
+            Log.Logger.Information("Order {Id{caret}} processed", order.Id);
+        }
+    }
+}

--- a/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestSerilogPositionalPropertyWithFormat.cs
+++ b/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestSerilogPositionalPropertyWithFormat.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main(DateTime timestamp)
+        {
+            Log.Logger.Information("Started at {0{caret}:HH:mm:ss}", timestamp);
+        }
+    }
+}

--- a/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestSerilogPositionalPropertyWithFormat.cs.gold
+++ b/test/data/QuickFixes/RenameTemplatePropertyFromArgumentFix/TestSerilogPositionalPropertyWithFormat.cs.gold
@@ -1,0 +1,13 @@
+﻿using System;
+using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main(DateTime timestamp)
+        {
+            Log.Logger.Information("Started at {Timestamp{caret}:HH:mm:ss}", timestamp);
+        }
+    }
+}

--- a/test/data/QuickFixes/RenameTemplatePropertyToQualifiedNameFix/TestSerilogPositionalProperty.cs
+++ b/test/data/QuickFixes/RenameTemplatePropertyToQualifiedNameFix/TestSerilogPositionalProperty.cs
@@ -1,0 +1,17 @@
+﻿using Serilog;
+
+namespace ConsoleApp
+{
+    public class Order
+    {
+        public int Id { get; set; }
+    }
+
+    public static class Program
+    {
+        public static void Main(Order order)
+        {
+            Log.Logger.Information("Order {0{caret}} processed", order.Id);
+        }
+    }
+}

--- a/test/data/QuickFixes/RenameTemplatePropertyToQualifiedNameFix/TestSerilogPositionalProperty.cs.gold
+++ b/test/data/QuickFixes/RenameTemplatePropertyToQualifiedNameFix/TestSerilogPositionalProperty.cs.gold
@@ -1,0 +1,17 @@
+﻿using Serilog;
+
+namespace ConsoleApp
+{
+    public class Order
+    {
+        public int Id { get; set; }
+    }
+
+    public static class Program
+    {
+        public static void Main(Order order)
+        {
+            Log.Logger.Information("Order {OrderId{caret}} processed", order.Id);
+        }
+    }
+}

--- a/test/data/QuickFixes/RenameTemplatePropertyToQualifiedNameFix/TestSerilogQualifiedNameNotOffered.cs
+++ b/test/data/QuickFixes/RenameTemplatePropertyToQualifiedNameFix/TestSerilogQualifiedNameNotOffered.cs
@@ -1,0 +1,12 @@
+﻿using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main(int quota)
+        {
+            Log.Logger.Information("Exceeded {0{caret}}", quota);
+        }
+    }
+}

--- a/test/data/QuickFixes/RenameTemplatePropertyToQualifiedNameFix/TestSerilogQualifiedNameNotOffered.cs.gold
+++ b/test/data/QuickFixes/RenameTemplatePropertyToQualifiedNameFix/TestSerilogQualifiedNameNotOffered.cs.gold
@@ -1,0 +1,16 @@
+﻿using Serilog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main(int quota)
+        {
+            Log.Logger.Information("Exceeded |{0}|(0)", quota);
+        }
+    }
+}
+
+------------------------------------------------
+0: Prefer named properties instead of positional ones
+NO QUICKFIXES

--- a/test/data/QuickFixes/RenameTemplatePropertyToQualifiedNameFix/TestSerilogQualifiedNameOffered.cs
+++ b/test/data/QuickFixes/RenameTemplatePropertyToQualifiedNameFix/TestSerilogQualifiedNameOffered.cs
@@ -1,0 +1,17 @@
+﻿using Serilog;
+
+namespace ConsoleApp
+{
+    public class Order
+    {
+        public int Id { get; set; }
+    }
+
+    public static class Program
+    {
+        public static void Main(Order order)
+        {
+            Log.Logger.Information("Order {0{caret}} processed", order.Id);
+        }
+    }
+}

--- a/test/data/QuickFixes/RenameTemplatePropertyToQualifiedNameFix/TestSerilogQualifiedNameOffered.cs.gold
+++ b/test/data/QuickFixes/RenameTemplatePropertyToQualifiedNameFix/TestSerilogQualifiedNameOffered.cs.gold
@@ -1,0 +1,22 @@
+﻿using Serilog;
+
+namespace ConsoleApp
+{
+    public class Order
+    {
+        public int Id { get; set; }
+    }
+
+    public static class Program
+    {
+        public static void Main(Order order)
+        {
+            Log.Logger.Information("Order |{0}|(0) processed", order.Id);
+        }
+    }
+}
+
+------------------------------------------------
+0: Prefer named properties instead of positional ones
+QUICKFIXES:
+Rename property to 'OrderId'

--- a/test/src/Analyzer/ComplexObjectDestructureAnalyzerTests.cs
+++ b/test/src/Analyzer/ComplexObjectDestructureAnalyzerTests.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace ReSharper.Structured.Logging.Tests.Analyzer
 {
@@ -27,5 +27,9 @@ namespace ReSharper.Structured.Logging.Tests.Analyzer
         [Test] public void TestSerilogCustomExceptionWithoutDestructure() => DoNamedTest2();
 
         [Test] public void TestSerilogParentWithOverriddenToString() => DoNamedTest2();
+
+        [Test] public void TestSerilogNamedArgumentsWithoutDestructure() => DoNamedTest2();
+
+        [Test] public void TestSerilogArrayArgumentsWithoutDestructure() => DoNamedTest2();
     }
 }

--- a/test/src/Analyzer/CorrectExceptionPassingAnalyzerTests.cs
+++ b/test/src/Analyzer/CorrectExceptionPassingAnalyzerTests.cs
@@ -13,5 +13,9 @@ namespace ReSharper.Structured.Logging.Tests.Analyzer
         [Test] public void TestSerilogIncorrectExceptionPassingDynamicTemplate() => DoNamedTest2();
 
         [Test] public void TestSerilogMultipleExceptionPassing() => DoNamedTest2();
+
+        [Test] public void TestSerilogNamedArgumentException() => DoNamedTest2();
+
+        [Test] public void TestSerilogExceptionInArrayArguments() => DoNamedTest2();
     }
 }

--- a/test/src/QuickFixes/MoveExceptionArgumentFixAvailabilityTests.cs
+++ b/test/src/QuickFixes/MoveExceptionArgumentFixAvailabilityTests.cs
@@ -21,5 +21,8 @@ namespace ReSharper.Structured.Logging.Tests.QuickFixes
         // Moving the exception would pass two of them, the dedicated argument is already taken
         [Test]
         public void TestSerilogExceptionArgumentOccupiedNotAvailable() => DoNamedTest();
+
+        [Test]
+        public void TestSerilogExceptionArgumentOccupiedByNewExceptionNotAvailable() => DoNamedTest();
     }
 }

--- a/test/src/QuickFixes/MoveExceptionArgumentFixAvailabilityTests.cs
+++ b/test/src/QuickFixes/MoveExceptionArgumentFixAvailabilityTests.cs
@@ -1,0 +1,25 @@
+﻿using JetBrains.ReSharper.FeaturesTestFramework.Intentions;
+using JetBrains.ReSharper.TestFramework;
+
+using NUnit.Framework;
+
+using ReSharper.Structured.Logging.QuickFixes;
+using ReSharper.Structured.Logging.Tests.Constants;
+
+namespace ReSharper.Structured.Logging.Tests.QuickFixes
+{
+    [TestFixture]
+    [TestNetFramework46]
+    [TestPackages(NugetPackages.SerilogNugetPackage)]
+    public class MoveExceptionArgumentFixAvailabilityTests : CSharpQuickFixAvailabilityTestBase<MoveExceptionArgumentFix>
+    {
+        protected override string RelativeTestDataPath => @"QuickFixes\MoveExceptionArgumentFix";
+
+        [Test]
+        public void TestSerilogExceptionAvailable() => DoNamedTest();
+
+        // Moving the exception would pass two of them, the dedicated argument is already taken
+        [Test]
+        public void TestSerilogExceptionArgumentOccupiedNotAvailable() => DoNamedTest();
+    }
+}

--- a/test/src/QuickFixes/MoveExceptionArgumentFixTests.cs
+++ b/test/src/QuickFixes/MoveExceptionArgumentFixTests.cs
@@ -1,0 +1,17 @@
+﻿using NUnit.Framework;
+
+using ReSharper.Structured.Logging.QuickFixes;
+
+namespace ReSharper.Structured.Logging.Tests.QuickFixes
+{
+    public class MoveExceptionArgumentFixTests : QuickFixTestBase<MoveExceptionArgumentFix>
+    {
+        protected override string SubPath => "MoveExceptionArgumentFix";
+
+        [Test] public void TestSerilogTrailingExceptionProperty() => DoNamedTest();
+
+        [Test] public void TestSerilogExceptionPropertyInTheMiddle() => DoNamedTest();
+
+        [Test] public void TestSerilogDynamicTemplate() => DoNamedTest();
+    }
+}

--- a/test/src/QuickFixes/RenameTemplatePropertyFixAvailabilityTests.cs
+++ b/test/src/QuickFixes/RenameTemplatePropertyFixAvailabilityTests.cs
@@ -1,0 +1,43 @@
+﻿using JetBrains.ReSharper.FeaturesTestFramework.Intentions;
+using JetBrains.ReSharper.TestFramework;
+
+using NUnit.Framework;
+
+using ReSharper.Structured.Logging.QuickFixes;
+using ReSharper.Structured.Logging.Tests.Constants;
+
+namespace ReSharper.Structured.Logging.Tests.QuickFixes
+{
+    [TestFixture]
+    [TestNetFramework46]
+    [TestPackages(NugetPackages.SerilogNugetPackage)]
+
+    // ReSharper disable once TestFileNameWarning
+    public class RenameTemplatePropertyFromArgumentFixAvailabilityTests
+        : CSharpQuickFixAvailabilityTestBase<RenameTemplatePropertyFromArgumentFix>
+    {
+        protected override string RelativeTestDataPath => @"QuickFixes\RenameTemplatePropertyFromArgumentFix";
+
+        [Test]
+        public void TestSerilogLeafNameOffered() => DoNamedTest();
+    }
+
+    [TestFixture]
+    [TestNetFramework46]
+    [TestPackages(NugetPackages.SerilogNugetPackage)]
+
+    // ReSharper disable once TestFileNameWarning
+    public class RenameTemplatePropertyToQualifiedNameFixAvailabilityTests
+        : CSharpQuickFixAvailabilityTestBase<RenameTemplatePropertyToQualifiedNameFix>
+    {
+        protected override string RelativeTestDataPath => @"QuickFixes\RenameTemplatePropertyToQualifiedNameFix";
+
+        // The qualified name differs from the leaf one, so it is offered as a second action
+        [Test]
+        public void TestSerilogQualifiedNameOffered() => DoNamedTest();
+
+        // A plain identifier has a single name, so there is no second action to offer
+        [Test]
+        public void TestSerilogQualifiedNameNotOffered() => DoNamedTest();
+    }
+}

--- a/test/src/QuickFixes/RenameTemplatePropertyFromArgumentFixDotNet6Tests.cs
+++ b/test/src/QuickFixes/RenameTemplatePropertyFromArgumentFixDotNet6Tests.cs
@@ -1,0 +1,22 @@
+﻿using JetBrains.ReSharper.FeaturesTestFramework.Intentions;
+using JetBrains.ReSharper.TestFramework;
+
+using NUnit.Framework;
+
+using ReSharper.Structured.Logging.QuickFixes;
+using ReSharper.Structured.Logging.Tests.Constants;
+
+namespace ReSharper.Structured.Logging.Tests.QuickFixes
+{
+    [TestFixture]
+    [TestNet60]
+    [TestPackages(NugetPackages.MicrosoftLoggingPackage)]
+    public class RenameTemplatePropertyFromArgumentFixDotNet6Tests : CSharpQuickFixTestBase<RenameTemplatePropertyFromArgumentFix>
+    {
+        protected override string RelativeTestDataPath => @"QuickFixes\RenameTemplatePropertyFromArgumentFix";
+
+        // An attribute template has no argument to name the hole after, so the duplicate is numbered instead
+        [Test]
+        public void TestLoggerMessageAttributeDuplicateProperty() => DoNamedTest();
+    }
+}

--- a/test/src/QuickFixes/RenameTemplatePropertyFromArgumentFixTests.cs
+++ b/test/src/QuickFixes/RenameTemplatePropertyFromArgumentFixTests.cs
@@ -1,0 +1,16 @@
+﻿using NUnit.Framework;
+
+using ReSharper.Structured.Logging.QuickFixes;
+
+namespace ReSharper.Structured.Logging.Tests.QuickFixes
+{
+    public class RenameTemplatePropertyFromArgumentFixTests : QuickFixTestBase<RenameTemplatePropertyFromArgumentFix>
+    {
+        protected override string SubPath => "RenameTemplatePropertyFromArgumentFix";
+
+        [Test] public void TestSerilogPositionalProperty() => DoNamedTest();
+
+        // The alignment and format of the hole survive the rename
+        [Test] public void TestSerilogPositionalPropertyWithFormat() => DoNamedTest();
+    }
+}

--- a/test/src/QuickFixes/RenameTemplatePropertyToQualifiedNameFixTests.cs
+++ b/test/src/QuickFixes/RenameTemplatePropertyToQualifiedNameFixTests.cs
@@ -1,0 +1,13 @@
+﻿using NUnit.Framework;
+
+using ReSharper.Structured.Logging.QuickFixes;
+
+namespace ReSharper.Structured.Logging.Tests.QuickFixes
+{
+    public class RenameTemplatePropertyToQualifiedNameFixTests : QuickFixTestBase<RenameTemplatePropertyToQualifiedNameFix>
+    {
+        protected override string SubPath => "RenameTemplatePropertyToQualifiedNameFix";
+
+        [Test] public void TestSerilogPositionalProperty() => DoNamedTest();
+    }
+}


### PR DESCRIPTION
Three related changes, one per commit, from reviewing the behavioural contract that
[alexaka1/structured-logging-analyzers](https://github.com/alexaka1/structured-logging-analyzers/blob/main/docs/compatibility.md)
recorded against this plugin. Both places where it deliberately *corrected* our behaviour turned out to
describe real defects here.

## Semantic hole binding

Holes were paired with arguments by source position — take every argument after the template and
subtract the template's index. That breaks for named, reordered and omitted optional arguments, and it
cannot tell an expanded `params` list from a single array.

`GetTemplateHoleArguments` binds through `MatchingParameter` instead: a hole value is an argument bound
to a parameter declared *after* the template parameter. That covers both the `params` overload and the
generic ones Serilog resolves for short argument lists, and it excludes the exception slot, the event id
and the extension receiver. When the values arrive as one array no hole can be tied to an expression, so
argument-dependent analysis is skipped rather than guessed.

```csharp
// not reported before: the destructure check looked at the argument after the template,
// which is the numeric one
logger.Information(propertyValue0: order, messageTemplate: "{First} {Second}", propertyValue1: 1);
```

This also fixes a latent negative index in `AnonymousTypeDestructureAnalyzer`, which filtered nothing
before indexing into `NamedProperties`.

## Exception placement

`CorrectExceptionPassingAnalyzer` returned on the first `Exception` argument in source order. When that
argument was the dedicated slot the scan stopped there, so a later exception consumed as a template
argument was never reported — including the noncompliant example in our own
`rules/ExceptionPassedAsTemplateArgumentProblem.md`. `SerilogMultipleExceptionPassing` pinned the miss
with an empty gold file; that gold now carries the warning.

The overload probe no longer compares argument positions against parameter positions (two different
coordinate systems); it asks whether a candidate overload declares an exception parameter before the
template parameter. That also removes a false positive:

```csharp
// was reported, the exception is written after the template but bound to the exception parameter
logger.Error(messageTemplate: "Disk quota exceeded", exception: exception);
```

## Three quick fixes

The rules below only reported a problem and left the rewrite to the reader.

**Pass exception to the exception argument.** Moves the argument into the dedicated slot and removes the
hole it filled, collapsing the separator left behind — exactly the compliant example in the rule doc. An
interpolated template keeps its text and only loses the argument. Not offered when another exception
already fills the slot, since that would pass two.

**Rename property to '…'** on positional and duplicate holes, built from the argument that fills the
hole, with the qualified name offered as a second action when it differs:

```csharp
logger.Information("Order {0} processed", order.Id);
// -> "Order {Id} processed"       (Rename property to 'Id')
// -> "Order {OrderId} processed"  (Rename property to 'OrderId')
```

Name derivation reuses the naming engine already driving the interpolation fix and honours the configured
naming style. Where no argument can name the hole — an attribute template, or values passed as one array —
a duplicate falls back to a numbered variant of its own name and a positional hole offers nothing.

The rename replaces exactly the name inside the hole, so alignment and format survive
(`{0,10:HH:mm:ss}` → `{Timestamp,10:HH:mm:ss}`). `RenameLogPropertyFix` still replaces everything between
the braces and drops them; left alone here, worth a follow-up.

Duplicate properties in a plain Serilog call are overlapped by the platform's own
`DuplicateItemInLoggerTemplateWarning`, so the duplicate rename is exercised through a `[LoggerMessage]`
attribute template, where our warning is the one shown.

## Validation

`build.cmd Test` and `build.cmd Test --is-rider-host`, plus Release as CI runs it: 119/119 in each.

The only pre-existing gold to change is `SerilogMultipleExceptionPassing`, which is the intended fix; the
other 102 tests were untouched by the binder rewrite. Twelve cases were added, covering named and
reordered arguments, values passed as an array, each new fix, and the negative cases where a fix must not
be offered.
