### PR TITLE
Add quick fixes for complex object destructuring in context

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and `Microsoft.Extensions.Logging.LoggerMessage.Define`/`DefineScope`.
 | [Message template highlighting](#highlighting) | — | [2021.2](https://www.jetbrains.com/help/resharper/Code_Analysis__String_Formatting_Methods.html) |
 | [Anonymous object is not destructured](rules/AnonymousObjectDestructuringProblem.md) | ✔ | — |
 | [Complex object is not destructured](rules/ComplexObjectDestructuringProblem.md) | ✔ | — |
-| [Complex object is not destructured in context](rules/ComplexObjectInContextDestructuringProblem.md) | — | — |
+| [Complex object is not destructured in context](rules/ComplexObjectInContextDestructuringProblem.md) | ✔ | — |
 | [Contextual logger mismatch](rules/ContextualLoggerProblem.md) | ✔ | — |
 | [Exception passed as a template argument](rules/ExceptionPassedAsTemplateArgumentProblem.md) | ✔ | — |
 | [Duplicate properties in a template](rules/TemplateDuplicatePropertyProblem.md) | ✔ | [2025.2](https://www.jetbrains.com/help/resharper/DuplicateItemInLoggerTemplate.html), Serilog-style calls only |

--- a/src/ReSharper.Structured.Logging/Highlighting/ComplexObjectDestructuringInContextWarning.cs
+++ b/src/ReSharper.Structured.Logging/Highlighting/ComplexObjectDestructuringInContextWarning.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using JetBrains.DocumentModel;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp;
@@ -24,25 +25,25 @@ namespace ReSharper.Structured.Logging.Highlighting
     {
         public const string SeverityId = "ComplexObjectInContextDestructuringProblem";
 
-        private readonly IInvocationExpression _invocationExpression;
-
-        public ComplexObjectDestructuringInContextWarning(IInvocationExpression invocationExpression)
+        public ComplexObjectDestructuringInContextWarning([NotNull] IInvocationExpression invocationExpression)
         {
-            _invocationExpression = invocationExpression;
+            InvocationExpression = invocationExpression;
         }
 
         public string ErrorStripeToolTip => ToolTip;
+
+        [NotNull] public IInvocationExpression InvocationExpression { get; }
 
         public string ToolTip => Message;
 
         public DocumentRange CalculateRange()
         {
-            return _invocationExpression.GetDocumentRange();
+            return InvocationExpression.GetDocumentRange();
         }
 
         public bool IsValid()
         {
-            return _invocationExpression.GetDocumentRange().IsValid();
+            return InvocationExpression.GetDocumentRange().IsValid();
         }
     }
 }

--- a/src/ReSharper.Structured.Logging/QuickFixes/ContextLogPropertyDestructuringFixBase.cs
+++ b/src/ReSharper.Structured.Logging/QuickFixes/ContextLogPropertyDestructuringFixBase.cs
@@ -1,0 +1,63 @@
+using System;
+
+using JetBrains.Annotations;
+using JetBrains.Application.Progress;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Feature.Services.QuickFixes;
+using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.CSharp;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Resources.Shell;
+using JetBrains.TextControl;
+using JetBrains.Util;
+
+using ReSharper.Structured.Logging.Highlighting;
+
+namespace ReSharper.Structured.Logging.QuickFixes
+{
+    /// <summary>
+    /// States how a context property is captured by appending the destructuring flag that
+    /// <c>LogContext.PushProperty</c> leaves optional.
+    /// </summary>
+    public abstract class ContextLogPropertyDestructuringFixBase : QuickFixBase
+    {
+        // The warning is only reported for Serilog's LogContext.PushProperty, so the flag is
+        // always declared under this name
+        private const string DestructureObjectsParameterName = "destructureObjects";
+
+        private readonly IInvocationExpression _invocationExpression;
+
+        protected ContextLogPropertyDestructuringFixBase([NotNull] ComplexObjectDestructuringInContextWarning error)
+        {
+            _invocationExpression = error.InvocationExpression;
+        }
+
+        /// <summary>
+        /// The value the appended flag is given.
+        /// </summary>
+        protected abstract bool DestructureObjects { get; }
+
+        public override bool IsAvailable(IUserDataHolder cache)
+        {
+            // The flag is appended, so the call has to be the two argument form the analyzer reports
+            return _invocationExpression.IsValid() && _invocationExpression.ArgumentList.Arguments.Count == 2;
+        }
+
+        protected override Action<ITextControl> ExecutePsiTransaction(ISolution solution, IProgressIndicator progress)
+        {
+            using (WriteLockCookie.Create())
+            {
+                var factory = CSharpElementFactory.GetInstance(_invocationExpression, false);
+                var arguments = _invocationExpression.ArgumentList.Arguments;
+                var value = factory.CreateExpression(DestructureObjects ? "true" : "false");
+
+                // A bare literal says nothing at the call site, the name is what makes the choice readable
+                _invocationExpression.AddArgumentAfter(
+                    factory.CreateArgument(ParameterKind.VALUE, DestructureObjectsParameterName, value),
+                    arguments[arguments.Count - 1]);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/ReSharper.Structured.Logging/QuickFixes/DestructureContextLogPropertyFix.cs
+++ b/src/ReSharper.Structured.Logging/QuickFixes/DestructureContextLogPropertyFix.cs
@@ -1,0 +1,25 @@
+using JetBrains.Annotations;
+using JetBrains.ReSharper.Feature.Services.QuickFixes;
+
+using ReSharper.Structured.Logging.Highlighting;
+
+namespace ReSharper.Structured.Logging.QuickFixes
+{
+    /// <summary>
+    /// Captures the property by its structure, so that
+    /// <c>LogContext.PushProperty("User", new User())</c> becomes
+    /// <c>LogContext.PushProperty("User", new User(), destructureObjects: true)</c>.
+    /// </summary>
+    [QuickFix]
+    public class DestructureContextLogPropertyFix : ContextLogPropertyDestructuringFixBase
+    {
+        public DestructureContextLogPropertyFix([NotNull] ComplexObjectDestructuringInContextWarning error)
+            : base(error)
+        {
+        }
+
+        public override string Text => "Destructure the property";
+
+        protected override bool DestructureObjects => true;
+    }
+}

--- a/src/ReSharper.Structured.Logging/QuickFixes/StringifyContextLogPropertyFix.cs
+++ b/src/ReSharper.Structured.Logging/QuickFixes/StringifyContextLogPropertyFix.cs
@@ -1,0 +1,27 @@
+using JetBrains.Annotations;
+using JetBrains.ReSharper.Feature.Services.QuickFixes;
+
+using ReSharper.Structured.Logging.Highlighting;
+
+namespace ReSharper.Structured.Logging.QuickFixes
+{
+    /// <summary>
+    /// Keeps the property a scalar rendered by <c>ToString()</c>, so that
+    /// <c>LogContext.PushProperty("User", new User())</c> becomes
+    /// <c>LogContext.PushProperty("User", new User(), destructureObjects: false)</c>. Offered next to
+    /// <see cref="DestructureContextLogPropertyFix"/>, since both are compliant and only the author
+    /// knows which one was meant.
+    /// </summary>
+    [QuickFix]
+    public class StringifyContextLogPropertyFix : ContextLogPropertyDestructuringFixBase
+    {
+        public StringifyContextLogPropertyFix([NotNull] ComplexObjectDestructuringInContextWarning error)
+            : base(error)
+        {
+        }
+
+        public override string Text => "Log the property as a string";
+
+        protected override bool DestructureObjects => false;
+    }
+}

--- a/test/data/Analyzers/ComplexTypeDestructure/SerilogContextNamedExplicitDestructure.cs
+++ b/test/data/Analyzers/ComplexTypeDestructure/SerilogContextNamedExplicitDestructure.cs
@@ -1,0 +1,14 @@
+using System;
+using Serilog;
+using Serilog.Context;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            LogContext.PushProperty("Test", new Random(), destructureObjects: true);
+        }
+    }
+}

--- a/test/data/Analyzers/ComplexTypeDestructure/SerilogContextNamedExplicitDestructure.cs.gold
+++ b/test/data/Analyzers/ComplexTypeDestructure/SerilogContextNamedExplicitDestructure.cs.gold
@@ -1,0 +1,16 @@
+﻿using System;
+using Serilog;
+using Serilog.Context;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            LogContext.PushProperty("Test", new Random(), destructureObjects: true);
+        }
+    }
+}
+
+---------------------------------------------------------

--- a/test/data/QuickFixes/DestructureContextLogPropertyFix/TestSerilogContextComplexObject.cs
+++ b/test/data/QuickFixes/DestructureContextLogPropertyFix/TestSerilogContextComplexObject.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Serilog;
+using Serilog.Context;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            LogContext.PushProperty("Test", new Ran{caret}dom());
+        }
+    }
+}

--- a/test/data/QuickFixes/DestructureContextLogPropertyFix/TestSerilogContextComplexObject.cs.gold
+++ b/test/data/QuickFixes/DestructureContextLogPropertyFix/TestSerilogContextComplexObject.cs.gold
@@ -1,0 +1,14 @@
+﻿using System;
+using Serilog;
+using Serilog.Context;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            LogContext.PushProperty("Test", new Ran{caret}dom(), destructureObjects: true);
+        }
+    }
+}

--- a/test/data/QuickFixes/DestructureContextLogPropertyFix/TestSerilogContextNamedArguments.cs
+++ b/test/data/QuickFixes/DestructureContextLogPropertyFix/TestSerilogContextNamedArguments.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Serilog;
+using Serilog.Context;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            LogContext.PushProperty(name: "Test", value: new Ran{caret}dom());
+        }
+    }
+}

--- a/test/data/QuickFixes/DestructureContextLogPropertyFix/TestSerilogContextNamedArguments.cs.gold
+++ b/test/data/QuickFixes/DestructureContextLogPropertyFix/TestSerilogContextNamedArguments.cs.gold
@@ -1,0 +1,14 @@
+﻿using System;
+using Serilog;
+using Serilog.Context;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            LogContext.PushProperty(name: "Test", value: new Ran{caret}dom(), destructureObjects: true);
+        }
+    }
+}

--- a/test/data/QuickFixes/StringifyContextLogPropertyFix/TestSerilogContextComplexObject.cs
+++ b/test/data/QuickFixes/StringifyContextLogPropertyFix/TestSerilogContextComplexObject.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Serilog;
+using Serilog.Context;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            LogContext.PushProperty("Test", new Ran{caret}dom());
+        }
+    }
+}

--- a/test/data/QuickFixes/StringifyContextLogPropertyFix/TestSerilogContextComplexObject.cs.gold
+++ b/test/data/QuickFixes/StringifyContextLogPropertyFix/TestSerilogContextComplexObject.cs.gold
@@ -1,0 +1,14 @@
+﻿using System;
+using Serilog;
+using Serilog.Context;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            LogContext.PushProperty("Test", new Ran{caret}dom(), destructureObjects: false);
+        }
+    }
+}

--- a/test/data/QuickFixes/StringifyContextLogPropertyFix/TestSerilogContextNamedArguments.cs
+++ b/test/data/QuickFixes/StringifyContextLogPropertyFix/TestSerilogContextNamedArguments.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Serilog;
+using Serilog.Context;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            LogContext.PushProperty(name: "Test", value: new Ran{caret}dom());
+        }
+    }
+}

--- a/test/data/QuickFixes/StringifyContextLogPropertyFix/TestSerilogContextNamedArguments.cs.gold
+++ b/test/data/QuickFixes/StringifyContextLogPropertyFix/TestSerilogContextNamedArguments.cs.gold
@@ -1,0 +1,14 @@
+﻿using System;
+using Serilog;
+using Serilog.Context;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            LogContext.PushProperty(name: "Test", value: new Ran{caret}dom(), destructureObjects: false);
+        }
+    }
+}

--- a/test/src/Analyzer/ComplexObjectDestructureAnalyzerTests.cs
+++ b/test/src/Analyzer/ComplexObjectDestructureAnalyzerTests.cs
@@ -24,6 +24,9 @@ namespace ReSharper.Structured.Logging.Tests.Analyzer
 
         [Test] public void TestSerilogContextExplicitDestructure() => DoNamedTest2();
 
+        // The shape the destructuring quick fixes produce
+        [Test] public void TestSerilogContextNamedExplicitDestructure() => DoNamedTest2();
+
         [Test] public void TestSerilogCustomExceptionWithoutDestructure() => DoNamedTest2();
 
         [Test] public void TestSerilogParentWithOverriddenToString() => DoNamedTest2();

--- a/test/src/QuickFixes/DestructureContextLogPropertyFixTests.cs
+++ b/test/src/QuickFixes/DestructureContextLogPropertyFixTests.cs
@@ -1,0 +1,16 @@
+using NUnit.Framework;
+
+using ReSharper.Structured.Logging.QuickFixes;
+
+namespace ReSharper.Structured.Logging.Tests.QuickFixes
+{
+    public class DestructureContextLogPropertyFixTests : QuickFixTestBase<DestructureContextLogPropertyFix>
+    {
+        protected override string SubPath => "DestructureContextLogPropertyFix";
+
+        [Test] public void TestSerilogContextComplexObject() => DoNamedTest();
+
+        // The flag is appended after the last argument rather than spliced into the list
+        [Test] public void TestSerilogContextNamedArguments() => DoNamedTest();
+    }
+}

--- a/test/src/QuickFixes/StringifyContextLogPropertyFixTests.cs
+++ b/test/src/QuickFixes/StringifyContextLogPropertyFixTests.cs
@@ -1,0 +1,16 @@
+using NUnit.Framework;
+
+using ReSharper.Structured.Logging.QuickFixes;
+
+namespace ReSharper.Structured.Logging.Tests.QuickFixes
+{
+    public class StringifyContextLogPropertyFixTests : QuickFixTestBase<StringifyContextLogPropertyFix>
+    {
+        protected override string SubPath => "StringifyContextLogPropertyFix";
+
+        [Test] public void TestSerilogContextComplexObject() => DoNamedTest();
+
+        // The flag is appended after the last argument rather than spliced into the list
+        [Test] public void TestSerilogContextNamedArguments() => DoNamedTest();
+    }
+}


### PR DESCRIPTION
Closes #171.

`ComplexObjectInContextDestructuringProblem` was the last analyzer without a quick fix. It reports a `LogContext.PushProperty` call that omits the destructuring flag for a value with no overridden `ToString()`, and left the rewrite to the reader.

Serilog declares the flag as an optional third parameter, so clearing the warning is a matter of appending one argument. `rules/ComplexObjectInContextDestructuringProblem.md` names both `true` and `false` as compliant, so the choice belongs to the author rather than to the fix — two bulb items are offered:

```csharp
// Destructure the property
LogContext.PushProperty("User", new User(), destructureObjects: true);

// Log the property as a string
LogContext.PushProperty("User", new User(), destructureObjects: false);
```

The flag goes in as a **named** argument: a bare `true` carries no meaning at the call site, which is exactly the readability the rule is about.

### Changes

* `DestructureContextLogPropertyFix` and `StringifyContextLogPropertyFix`, sharing the argument surgery in `ContextLogPropertyDestructuringFixBase` — the same shape as the `RenameTemplatePropertyFixBase` pair added in #168, since the SDK binds a fix to a highlighting by constructor parameter type.
* `ComplexObjectDestructuringInContextWarning` now exposes the invocation it reports so a fix can act on it. Its range is unchanged.
* A quick-fix test per fix, each covering the plain call and a call whose arguments are already named, so the flag is pinned to land after the last argument rather than being spliced into the list.
* `SerilogContextNamedExplicitDestructure` pins that the shape the fixes produce is clean, next to the existing positional `SerilogContextExplicitDestructure`.
* The *Complex object is not destructured in context* row in the README now reads ✔. The rule doc is unchanged — both the positional and the named form are compliant, and it describes the rule, not the fix.

### Validation

* `build.cmd Compile` — 0 warnings, 0 errors.
* `build.cmd Test` — 123 passed, 0 failed (118 before).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added quick fixes for context log properties to either destructure complex objects or render them using `ToString()`.
  - Quick fixes support calls using both positional and named arguments.
  - Updated analyzer documentation to indicate quick-fix availability.

- **Tests**
  - Added coverage for both quick-fix options, including named-argument scenarios and correct argument placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->