### PR TITLE
Support NLog scope properties in the context naming analyzer

### DIFF
--- a/rules/ComplexObjectInContextDestructuringProblem.md
+++ b/rules/ComplexObjectInContextDestructuringProblem.md
@@ -27,3 +27,5 @@ LogContext.PushProperty("User", new User(), true);
 
 LogContext.PushProperty("User", new User(), false);
 ```
+
+Serilog only: NLog's `ScopeContext.PushProperty` has no destructuring flag to set, so it is not reported.

--- a/rules/InconsistentContextLogPropertyNaming.md
+++ b/rules/InconsistentContextLogPropertyNaming.md
@@ -2,10 +2,20 @@
 
 Noncompliant Code Examples:
 ```csharp
+// Serilog
 LogContext.PushProperty("property_name", 1);
+
+// NLog
+ScopeContext.PushProperty("property_name", 1);
+logger.PushScopeProperty("property_name", 1);
 ```
 
 Compliant Solution:
 ```csharp
+// Serilog
 LogContext.PushProperty("PropertyName", 1);
+
+// NLog
+ScopeContext.PushProperty("PropertyName", 1);
+logger.PushScopeProperty("PropertyName", 1);
 ```

--- a/src/ReSharper.Structured.Logging/Analyzer/PropertiesNamingAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/PropertiesNamingAnalyzer.cs
@@ -94,7 +94,7 @@ public class PropertiesNamingAnalyzer : ElementProblemAnalyzer<ICSharpArgumentsO
         IContextBoundSettingsStore settingsStore,
         Regex ignoredPropertiesRegex)
     {
-        if (!element.IsSerilogContextPushPropertyMethod())
+        if (!element.IsContextPushPropertyMethod())
         {
             return;
         }

--- a/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
+++ b/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
@@ -24,10 +24,18 @@ namespace ReSharper.Structured.Logging.Extensions
 {
     public static class PsiExtensions
     {
+        private const string PushPropertyMethodName = "PushProperty";
+
+        private const string PushScopePropertyMethodName = "PushScopeProperty";
+
         private static readonly IClrTypeName LogContextFqn = new ClrTypeName("Serilog.Context.LogContext");
 
         private static readonly IClrTypeName LoggerMessageFqn =
             new ClrTypeName("Microsoft.Extensions.Logging.LoggerMessage");
+
+        private static readonly IClrTypeName NLogLoggerFqn = new ClrTypeName("NLog.Logger");
+
+        private static readonly IClrTypeName ScopeContextFqn = new ClrTypeName("NLog.ScopeContext");
 
         [CanBeNull]
         public static ICSharpArgument GetTemplateArgument(
@@ -324,6 +332,10 @@ namespace ReSharper.Structured.Logging.Extensions
             return LoggerMessageFqn.Equals(containingType.GetClrName());
         }
 
+        /// <summary>
+        /// Serilog only, unlike <see cref="IsContextPushPropertyMethod"/>: the destructuring analysis this
+        /// feeds is about the optional <c>destructureObjects</c> flag, which no other logger declares.
+        /// </summary>
         public static bool IsSerilogContextPushPropertyMethod(this IInvocationExpression invocationExpression)
         {
             var typeMember = invocationExpression.Reference.Resolve()
@@ -334,7 +346,32 @@ namespace ReSharper.Structured.Logging.Extensions
                 return false;
             }
 
-            return LogContextFqn.Equals(containingType.GetClrName()) && typeMember.ShortName == "PushProperty";
+            return LogContextFqn.Equals(containingType.GetClrName()) && typeMember.ShortName == PushPropertyMethodName;
+        }
+
+        /// <summary>
+        /// Matches the scope property calls that name the property in their first argument: Serilog's
+        /// <c>LogContext.PushProperty</c>, NLog's <c>ScopeContext.PushProperty</c> and NLog's
+        /// <c>Logger.PushScopeProperty</c>. The generic NLog overloads carry the same short name,
+        /// so they are matched as well.
+        /// </summary>
+        public static bool IsContextPushPropertyMethod(this IInvocationExpression invocationExpression)
+        {
+            var typeMember = invocationExpression.Reference?.Resolve()
+                .DeclaredElement as ITypeMember;
+            var containingType = typeMember?.GetContainingType();
+            if (containingType == null)
+            {
+                return false;
+            }
+
+            var containingTypeName = containingType.GetClrName();
+            if (LogContextFqn.Equals(containingTypeName) || ScopeContextFqn.Equals(containingTypeName))
+            {
+                return typeMember.ShortName == PushPropertyMethodName;
+            }
+
+            return NLogLoggerFqn.Equals(containingTypeName) && typeMember.ShortName == PushScopePropertyMethodName;
         }
 
         [CanBeNull]

--- a/test/data/Analyzers/ComplexTypeDestructure/NlogScopeContextWithoutDestructure.cs
+++ b/test/data/Analyzers/ComplexTypeDestructure/NlogScopeContextWithoutDestructure.cs
@@ -1,0 +1,15 @@
+using System;
+using NLog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            using (ScopeContext.PushProperty("Test", new Random()))
+            {
+            }
+        }
+    }
+}

--- a/test/data/Analyzers/ComplexTypeDestructure/NlogScopeContextWithoutDestructure.cs.gold
+++ b/test/data/Analyzers/ComplexTypeDestructure/NlogScopeContextWithoutDestructure.cs.gold
@@ -1,0 +1,17 @@
+﻿using System;
+using NLog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            using (ScopeContext.PushProperty("Test", new Random()))
+            {
+            }
+        }
+    }
+}
+
+---------------------------------------------------------

--- a/test/data/Analyzers/PropertiesNamingAnalyzer/NlogLoggerScopePropertyInvalidNamedProperty.cs
+++ b/test/data/Analyzers/PropertiesNamingAnalyzer/NlogLoggerScopePropertyInvalidNamedProperty.cs
@@ -1,0 +1,16 @@
+using NLog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+        public static void Main()
+        {
+            using (Log.PushScopeProperty("test", 1))
+            {
+            }
+        }
+    }
+}

--- a/test/data/Analyzers/PropertiesNamingAnalyzer/NlogLoggerScopePropertyInvalidNamedProperty.cs.gold
+++ b/test/data/Analyzers/PropertiesNamingAnalyzer/NlogLoggerScopePropertyInvalidNamedProperty.cs.gold
@@ -1,0 +1,19 @@
+﻿using NLog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+        public static void Main()
+        {
+            using (Log.PushScopeProperty(|"test"|(0), 1))
+            {
+            }
+        }
+    }
+}
+
+---------------------------------------------------------
+(0): ReSharper Warning: Property name 'test' does not match naming rules. Suggested name is 'Test'.

--- a/test/data/Analyzers/PropertiesNamingAnalyzer/NlogScopeContextInvalidNamedProperty.cs
+++ b/test/data/Analyzers/PropertiesNamingAnalyzer/NlogScopeContextInvalidNamedProperty.cs
@@ -1,0 +1,18 @@
+using NLog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            using (ScopeContext.PushProperty("test", 1))
+            {
+            }
+
+            using (ScopeContext.PushProperty("myProperty", (object)1))
+            {
+            }
+        }
+    }
+}

--- a/test/data/Analyzers/PropertiesNamingAnalyzer/NlogScopeContextInvalidNamedProperty.cs.gold
+++ b/test/data/Analyzers/PropertiesNamingAnalyzer/NlogScopeContextInvalidNamedProperty.cs.gold
@@ -1,0 +1,22 @@
+﻿using NLog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            using (ScopeContext.PushProperty(|"test"|(0), 1))
+            {
+            }
+
+            using (ScopeContext.PushProperty(|"myProperty"|(1), (object)1))
+            {
+            }
+        }
+    }
+}
+
+---------------------------------------------------------
+(0): ReSharper Warning: Property name 'test' does not match naming rules. Suggested name is 'Test'.
+(1): ReSharper Warning: Property name 'myProperty' does not match naming rules. Suggested name is 'MyProperty'.

--- a/test/data/Analyzers/PropertiesNamingAnalyzer/NlogScopeContextValidNamedProperty.cs
+++ b/test/data/Analyzers/PropertiesNamingAnalyzer/NlogScopeContextValidNamedProperty.cs
@@ -1,0 +1,14 @@
+using NLog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            using (ScopeContext.PushProperty("Test", 1))
+            {
+            }
+        }
+    }
+}

--- a/test/data/Analyzers/PropertiesNamingAnalyzer/NlogScopeContextValidNamedProperty.cs.gold
+++ b/test/data/Analyzers/PropertiesNamingAnalyzer/NlogScopeContextValidNamedProperty.cs.gold
@@ -1,0 +1,16 @@
+﻿using NLog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            using (ScopeContext.PushProperty("Test", 1))
+            {
+            }
+        }
+    }
+}
+
+---------------------------------------------------------

--- a/test/data/QuickFixes/RenameContextLogPropertyFix/TestNlogLoggerScopeProperty.cs
+++ b/test/data/QuickFixes/RenameContextLogPropertyFix/TestNlogLoggerScopeProperty.cs
@@ -1,0 +1,16 @@
+using NLog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+        public static void Main()
+        {
+            using (Log.PushScopeProperty("{caret}test", 1))
+            {
+            }
+        }
+    }
+}

--- a/test/data/QuickFixes/RenameContextLogPropertyFix/TestNlogLoggerScopeProperty.cs.gold
+++ b/test/data/QuickFixes/RenameContextLogPropertyFix/TestNlogLoggerScopeProperty.cs.gold
@@ -1,0 +1,16 @@
+﻿using NLog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+        public static void Main()
+        {
+            using (Log.PushScopeProperty("T{caret}est", 1))
+            {
+            }
+        }
+    }
+}

--- a/test/data/QuickFixes/RenameContextLogPropertyFix/TestNlogScopeContextProperty.cs
+++ b/test/data/QuickFixes/RenameContextLogPropertyFix/TestNlogScopeContextProperty.cs
@@ -1,0 +1,14 @@
+using NLog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            using (ScopeContext.PushProperty("{caret}test", 1))
+            {
+            }
+        }
+    }
+}

--- a/test/data/QuickFixes/RenameContextLogPropertyFix/TestNlogScopeContextProperty.cs.gold
+++ b/test/data/QuickFixes/RenameContextLogPropertyFix/TestNlogScopeContextProperty.cs.gold
@@ -1,0 +1,14 @@
+﻿using NLog;
+
+namespace ConsoleApp
+{
+    public static class Program
+    {
+        public static void Main()
+        {
+            using (ScopeContext.PushProperty("T{caret}est", 1))
+            {
+            }
+        }
+    }
+}

--- a/test/src/Analyzer/ComplexObjectDestructureAnalyzerTests.cs
+++ b/test/src/Analyzer/ComplexObjectDestructureAnalyzerTests.cs
@@ -27,6 +27,9 @@ namespace ReSharper.Structured.Logging.Tests.Analyzer
         // The shape the destructuring quick fixes produce
         [Test] public void TestSerilogContextNamedExplicitDestructure() => DoNamedTest2();
 
+        // NLog has no destructuring flag to add, so the warning stays away from its scope properties
+        [Test] public void TestNlogScopeContextWithoutDestructure() => DoNamedTest2();
+
         [Test] public void TestSerilogCustomExceptionWithoutDestructure() => DoNamedTest2();
 
         [Test] public void TestSerilogParentWithOverriddenToString() => DoNamedTest2();

--- a/test/src/Analyzer/PropertiesNamingAnalyzerTests.cs
+++ b/test/src/Analyzer/PropertiesNamingAnalyzerTests.cs
@@ -16,6 +16,12 @@ namespace ReSharper.Structured.Logging.Tests.Analyzer
 
         [Test] public void TestSerilogContextInterpolatedStringProperty() => DoNamedTest2();
 
+        [Test] public void TestNlogScopeContextInvalidNamedProperty() => DoNamedTest2();
+
+        [Test] public void TestNlogScopeContextValidNamedProperty() => DoNamedTest2();
+
+        [Test] public void TestNlogLoggerScopePropertyInvalidNamedProperty() => DoNamedTest2();
+
         [Test] public void TestSerilogInvalidNamedPropertyWithDot() => DoNamedTest2();
 
         [Test] public void TestSerilogInvalidSyntax() => DoNamedTest2();

--- a/test/src/Constants/NugetPackages.cs
+++ b/test/src/Constants/NugetPackages.cs
@@ -6,7 +6,7 @@ namespace ReSharper.Structured.Logging.Tests.Constants
 
         public const string MicrosoftLoggingPackage = "Microsoft.Extensions.Logging/6.0.0";
 
-        public const string NlogLoggingPackage = "NLog/4.5.11";
+        public const string NlogLoggingPackage = "NLog/6.2.0";
 
         public const string ZLoggerLoggingPackage = "ZLogger/1.7.0";
     }

--- a/test/src/QuickFixes/RenameContextLogPropertyFixTests.cs
+++ b/test/src/QuickFixes/RenameContextLogPropertyFixTests.cs
@@ -9,5 +9,9 @@ namespace ReSharper.Structured.Logging.Tests.QuickFixes
         protected override string SubPath => "RenameContextLogPropertyFix";
 
         [Test] public void TestSerilogContextProperty() => DoNamedTest();
+
+        [Test] public void TestNlogScopeContextProperty() => DoNamedTest();
+
+        [Test] public void TestNlogLoggerScopeProperty() => DoNamedTest();
     }
 }


### PR DESCRIPTION
Fixes #166

`InconsistentContextLogPropertyNaming` only fired for Serilog's `LogContext.PushProperty`, so NLog users got the template analyzers but none of the scope-property naming checks.

### Behaviour

`InconsistentContextLogPropertyNaming` and its `RenameContextLogPropertyFix` now also cover:

- `NLog.ScopeContext.PushProperty(string, object)` and the generic `PushProperty<TValue>`
- `NLog.Logger.PushScopeProperty(string, object)`, the instance-method equivalent NLog 5 documents alongside `ScopeContext`

```csharp
using (ScopeContext.PushProperty("order_id", orderId))   // now reported, rename to OrderId
{
    logger.Info("Processing order");
}
```

`ComplexObjectInContextDestructuring` stays Serilog-only. NLog's `PushProperty` has no `destructureObjects` parameter, so `DestructureContextLogPropertyFix` and `StringifyContextLogPropertyFix` would produce code that does not compile, and a warning with no applicable fix is just noise. A regression test locks that in, and the rule page now says so.

### Implementation

`PsiExtensions.IsSerilogContextPushPropertyMethod` gated both analyzers. It stays as-is for the destructuring one, and a new `IsContextPushPropertyMethod` matches all three shapes that name the property in their first argument. `PropertiesNamingAnalyzer.CheckPropertiesInContext` already read the key positionally from `Arguments[0]`, which is correct for every one of them, so nothing else needed changing.

### Scope decisions from the issue

- `PushProperties(IReadOnlyCollection<KeyValuePair<...>>)` is not handled — the keys sit inside a collection initializer and need different argument walking than `Arguments[0]`.
- The `[Obsolete]` NLog 4 equivalents `MappedDiagnosticsLogicalContext.SetScoped` / `MappedDiagnosticsContext.SetScoped` are out too.

### Tests

The NLog test package moves from 4.5.11 to 6.2.0 — `ScopeContext` needs NLog 5 or newer, and 6.2.0 still ships a `net46` asset for the `[TestNetFramework46]` quick-fix fixtures. No test data referenced NLog before, so nothing regressed.

Six new tests: the naming warning on `ScopeContext.PushProperty` (covering both the generic and `object` overloads) and on `Logger.PushScopeProperty`, a negative case for an already-Pascal name, the rename quick fix on both NLog forms, and `TestNlogScopeContextWithoutDestructure` asserting the destructuring warning stays away.

### Validation

- `build.cmd Compile`
- `build.cmd Test` — 129/129 passed
- `build.cmd Test --is-rider-host` — 129/129 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for analyzing NLog scope and logger-scope context properties.
  * NLog context property names now receive PascalCase naming diagnostics and rename quick-fixes.
* **Bug Fixes**
  * Corrected destructuring analysis so NLog scope properties are not flagged when no destructuring option exists.
* **Documentation**
  * Expanded guidance and examples for Serilog and NLog context properties.
* **Tests**
  * Added coverage for NLog naming diagnostics, quick-fixes, and destructuring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->