### PR TITLE
Replace CI-based Sonar analysis with SonarQube Cloud Automatic Analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v6
@@ -72,20 +70,6 @@ jobs:
 
       - name: Pack Rider plugin
         run: .\build.cmd PackRiderPlugin --configuration Release --is-rider-host
-
-      - name: Analyze with SonarCloud
-        if: >-
-          github.event_name != 'pull_request' ||
-          (github.event.pull_request.head.repo.full_name == github.repository &&
-          github.actor != 'dependabot[bot]')
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:SONAR_TOKEN)) {
-            throw "The SONAR_TOKEN repository secret is required for trusted builds."
-          }
-
-          .\build.cmd Sonar --configuration Release
 
       - name: Upload ReSharper package
         uses: actions/upload-artifact@v7

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -31,8 +31,6 @@
         "PublishReSharperPlugin",
         "PublishRiderPlugin",
         "RunIde",
-        "Sonar",
-        "SonarBegin",
         "Test"
       ]
     },
@@ -119,10 +117,6 @@
         },
         "RunIdeSolution": {
           "type": "string"
-        },
-        "SonarToken": {
-          "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         }
       }
     },

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,9 @@
+# Configuration for SonarQube Cloud Automatic Analysis.
+# Automatic Analysis reads THIS file and ignores sonar-project.properties.
+# It is only honoured on the default branch.
+# https://docs.sonarsource.com/sonarqube-cloud/analyzing-source-code/automatic-analysis
+
+# build.* are Nuke's generated bootstrappers and gradlew* are Gradle's wrappers - generated
+# code we do not hand-maintain. test/data holds analyzer fixtures: deliberately malformed C#
+# paired with .gold expectations, so grading it produces noise rather than signal.
+sonar.exclusions=build.cmd,build.ps1,build.sh,gradlew,gradlew.bat,test/data/**

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -12,13 +12,11 @@ using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.NuGet;
 using Nuke.Common.Tools.NUnit;
-using Nuke.Common.Tools.SonarScanner;
 using Nuke.Common.Utilities.Collections;
 
 using static Nuke.Common.EnvironmentInfo;
 using static Nuke.Common.Tools.NUnit.NUnitTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
-using static Nuke.Common.Tools.SonarScanner.SonarScannerTasks;
 using static Nuke.Common.Tools.NuGet.NuGetTasks;
 
 [ShutdownDotNetAfterServerBuild]
@@ -59,8 +57,6 @@ class Build : NukeBuild
     [Parameter] readonly string Configuration = "Release";
 
     [Parameter] readonly bool IsRiderHost;
-
-    [Parameter] [Secret] readonly string SonarToken;
 
     [Parameter] [Secret] readonly string MarketplaceToken;
 
@@ -258,33 +254,6 @@ class Build : NukeBuild
                     // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
                     Serilog.Log.Information(s);
                 });
-        });
-
-    Target SonarBegin => _ => _
-        .Unlisted()
-        .Before(Compile)
-        .Requires(() => SonarToken)
-        .Executes(() =>
-        {
-            SonarScannerBegin(s => s
-                .SetServer("https://sonarcloud.io")
-                .SetFramework("net5.0")
-                .SetToken(SonarToken)
-                .SetProjectKey("resharper-structured-logging")
-                .SetName("ReSharper Structured Logging")
-                .SetOrganization("olsh")
-                .SetVersion(ExtensionVersion));
-        });
-
-    Target Sonar => _ => _
-        .DependsOn(SonarBegin, Compile)
-        .Requires(() => !IsRiderHost)
-        .Requires(() => SonarToken)
-        .Executes(() =>
-        {
-            SonarScannerEnd(s => s
-                .SetToken(SonarToken)
-                .SetFramework("net5.0"));
         });
 
     // Replaces AppVeyor's UpdateBuildVersion, which used to display the extension version on the

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -21,7 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="dotnet-sonarscanner" Version="[11.2.1]" />
     <PackageDownload Include="NuGet.CommandLine" Version="[7.9.0]" />
     <PackageDownload Include="NUnit.ConsoleRunner" Version="[3.22.0]" />
     <PackageDownload Include="dotnet-cleanup" Version="[1.0.1]" />


### PR DESCRIPTION
Follows the same migration already completed in [todoist-net#82](https://github.com/olsh/todoist-net/pull/82), where it has been validated end to end.

## Why

The `Analyze with SonarCloud` step could never run on pull requests from forks — GitHub withholds secrets from them — so it carried an `if:` skipping any PR not from this repository. **Fork contributions were never analyzed at all.**

SonarSource confirmed in [February 2025](https://community.sonarsource.com/t/sonarcloud-2025-pull-request-decoration-of-fork-not-working-with-github/135058):

> "SonarCloud is now able to scan External Pull Requests when the project is configured to be scanned with Automatic Analysis"

So this doesn't just remove machinery — it gains fork-PR analysis the repo never had.

## What changed

- Dropped the `Analyze with SonarCloud` step and its fork/dependabot carve-out.
- Dropped `fetch-depth: 0`; nothing else here reads git history (the version comes from the SDK version plus `GitHubActions.RunNumber`).
- Removed the `SonarBegin`/`Sonar` targets, the `SonarToken` parameter and the SonarScanner usings from `build/Build.cs`.
- Removed the `dotnet-sonarscanner` package download; regenerated `.nuke/build.schema.json`.

**The Java setup stays** — Gradle needs it for the Rider plugin, it was never Sonar's. `[CI] GitHubActions` also stays: it feeds the extension version and the job summary.

Verified with `dotnet build build/_build.csproj` — succeeds, 0 warnings.

## Note on the MSBuild Sonar properties

`SonarQubeExclude` / `SonarQubeTestProject` in `ReSharper.Structured.Logging.Rider.csproj`, `ReSharper.Structured.Logging.csproj` and `ReSharper.Structured.Logging.Rider.Tests.csproj` are read by SonarScanner for .NET during the MSBuild integration. Automatic Analysis doesn't run MSBuild, so **those exclusions stop taking effect** and the Rider test project will start being analyzed.

Left in place deliberately (harmless, and needed if this is ever reverted). If the exclusions matter, reproduce them server-side under Administration → Analysis Scope. Expect the issue count to rise from the current baseline of 21 for this reason.

## Follow-up (not in this PR)

1. Merge this **first**, then enable Automatic Analysis (Administration → Analysis Method). Enabling it while CI still ran Sonar would fail the build.
2. Once a push to master is analyzed, delete the `SONAR_TOKEN` secret (keep `JETBRAINS_MARKETPLACE_TOKEN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4f13Y3eK8vyN3rFwviRHX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed SonarCloud analysis from the build workflow.
  * Removed SonarScanner integration and related build configuration.
  * Builds no longer require the Sonar token or SonarScanner package.
  * Source checkout uses the default history depth.
  * Added SonarCloud analysis exclusions for generated build files, Gradle wrapper files, and analyzer fixture data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->