### PR TITLE
Cover Log.ForContext and ILoggerFactory.CreateLogger in the contextual logger check

### DIFF
--- a/rules/ContextualLoggerProblem.md
+++ b/rules/ContextualLoggerProblem.md
@@ -13,6 +13,15 @@ class B {}
 ```csharp
 class A
 {
+    private static readonly ILogger Logger = Log.ForContext<B>();
+}
+
+class B { }
+```
+
+```csharp
+class A
+{
 	ILogger<B> _log;
 	
 	public A(ILogger<B> log)
@@ -33,6 +42,20 @@ class A(ILogger<B> log)
 class B { } 
 ```
 
+```csharp
+class A
+{
+	ILogger _log;
+
+	public A(ILoggerFactory loggerFactory)
+	{
+		_log = loggerFactory.CreateLogger<B>();
+	}
+}
+
+class B { }
+```
+
 Compliant Solution:
 ```csharp
 class A
@@ -41,6 +64,15 @@ class A
 }
 
 class B {} 
+```
+
+```csharp
+class A
+{
+    private static readonly ILogger Logger = Log.ForContext<A>();
+}
+
+class B { }
 ```
 
 ```csharp
@@ -64,4 +96,18 @@ class A(ILogger<A> log)
 }
 
 class B {} 
+```
+
+```csharp
+class A
+{
+	ILogger _log;
+
+	public A(ILoggerFactory loggerFactory)
+	{
+		_log = loggerFactory.CreateLogger<A>();
+	}
+}
+
+class B { }
 ```

--- a/src/ReSharper.Structured.Logging/Analyzer/ContextualLoggerFactoryAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/ContextualLoggerFactoryAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;
+using JetBrains.ReSharper.Psi.Util;
 
 using ReSharper.Structured.Logging.Extensions;
 using ReSharper.Structured.Logging.Highlighting;
@@ -8,11 +9,11 @@ using ReSharper.Structured.Logging.Highlighting;
 namespace ReSharper.Structured.Logging.Analyzer
 {
     [ElementProblemAnalyzer(typeof(IInvocationExpression))]
-    public class ContextualLoggerSerilogFactoryAnalyzer : ElementProblemAnalyzer<IInvocationExpression>
+    public class ContextualLoggerFactoryAnalyzer : ElementProblemAnalyzer<IInvocationExpression>
     {
         protected override void Run(IInvocationExpression element, ElementProblemAnalyzerData data, IHighlightingConsumer consumer)
         {
-            if (!element.IsSerilogContextFactoryLogger())
+            if (!element.IsContextualLoggerFactoryMethod())
             {
                 return;
             }
@@ -23,8 +24,18 @@ namespace ReSharper.Structured.Logging.Analyzer
                 return;
             }
 
-            var invocationTypeArgument = element.TypeArguments[0]?.GetScalarType()?.GetClrName();
-            if (invocationTypeArgument?.FullName == containingNode.CLRName)
+            var contextType = element.TypeArguments[0];
+
+            // A generic wrapper such as ILogger<T> Create<T>(ILoggerFactory factory) => factory.CreateLogger<T>()
+            // names its own type parameter, so the caller of the wrapper decides the context, not this call.
+            if (contextType == null || contextType.IsTypeParameterType())
+            {
+                return;
+            }
+
+            if (contextType.GetScalarType()
+                    ?.GetClrName()
+                    .FullName == containingNode.CLRName)
             {
                 return;
             }

--- a/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
+++ b/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
@@ -24,11 +24,18 @@ namespace ReSharper.Structured.Logging.Extensions
 {
     public static class PsiExtensions
     {
+        private const string CreateLoggerMethodName = "CreateLogger";
+
+        private const string ForContextMethodName = "ForContext";
+
         private const string PushPropertyMethodName = "PushProperty";
 
         private const string PushScopePropertyMethodName = "PushScopeProperty";
 
         private static readonly IClrTypeName LogContextFqn = new ClrTypeName("Serilog.Context.LogContext");
+
+        private static readonly IClrTypeName LoggerFactoryExtensionsFqn =
+            new ClrTypeName("Microsoft.Extensions.Logging.LoggerFactoryExtensions");
 
         private static readonly IClrTypeName LoggerMessageFqn =
             new ClrTypeName("Microsoft.Extensions.Logging.LoggerMessage");
@@ -36,6 +43,10 @@ namespace ReSharper.Structured.Logging.Extensions
         private static readonly IClrTypeName NLogLoggerFqn = new ClrTypeName("NLog.Logger");
 
         private static readonly IClrTypeName ScopeContextFqn = new ClrTypeName("NLog.ScopeContext");
+
+        private static readonly IClrTypeName SerilogLogFqn = new ClrTypeName("Serilog.Log");
+
+        private static readonly IClrTypeName SerilogLoggerFqn = new ClrTypeName("Serilog.ILogger");
 
         [CanBeNull]
         public static ICSharpArgument GetTemplateArgument(
@@ -291,28 +302,36 @@ namespace ReSharper.Structured.Logging.Extensions
                 .FullName == "Microsoft.Extensions.Logging.ILogger`1";
         }
 
-        public static bool IsSerilogContextFactoryLogger([NotNull] this IInvocationExpression invocationExpression)
+        /// <summary>
+        /// Matches the calls that build a logger categorised for a type: Serilog's
+        /// <c>ILogger.ForContext&lt;T&gt;()</c> and the <c>Log.ForContext&lt;T&gt;()</c> static facade, and
+        /// <c>ILoggerFactory.CreateLogger&lt;T&gt;()</c>. Requiring a single type argument leaves out the
+        /// overloads that name the category some other way, such as <c>ForContext(string, object)</c>,
+        /// <c>CreateLogger(string)</c> and the <c>Type</c> ones.
+        /// </summary>
+        public static bool IsContextualLoggerFactoryMethod([NotNull] this IInvocationExpression invocationExpression)
         {
             if (invocationExpression.TypeArguments.Count != 1)
             {
                 return false;
             }
 
-            var declaredElement = invocationExpression.Reference.Resolve()
-                .DeclaredElement as IClrDeclaredElement;
-            var containingType = declaredElement?.GetContainingType();
+            var typeMember = invocationExpression.Reference?.Resolve()
+                .DeclaredElement as ITypeMember;
+            var containingType = typeMember?.GetContainingType();
             if (containingType == null)
             {
                 return false;
             }
 
-            if (containingType.GetClrName()
-                    .FullName == "Serilog.ILogger" && declaredElement.ShortName == "ForContext")
+            var containingTypeName = containingType.GetClrName();
+            if (SerilogLoggerFqn.Equals(containingTypeName) || SerilogLogFqn.Equals(containingTypeName))
             {
-                return true;
+                return typeMember.ShortName == ForContextMethodName;
             }
 
-            return false;
+            return LoggerFactoryExtensionsFqn.Equals(containingTypeName)
+                   && typeMember.ShortName == CreateLoggerMethodName;
         }
 
         /// <summary>

--- a/src/ReSharper.Structured.Logging/Highlighting/ContextualLoggerWarning.cs
+++ b/src/ReSharper.Structured.Logging/Highlighting/ContextualLoggerWarning.cs
@@ -47,8 +47,8 @@ namespace ReSharper.Structured.Logging.Highlighting
         public ITypeElement ExpectedType { get; }
 
         /// <summary>
-        /// The parameter the logger is declared on, or <c>null</c> when the warning comes from a
-        /// Serilog <c>ForContext&lt;T&gt;()</c> call.
+        /// The parameter the logger is declared on, or <c>null</c> when the warning comes from a factory
+        /// call such as <c>ForContext&lt;T&gt;()</c> or <c>CreateLogger&lt;T&gt;()</c>.
         /// </summary>
         [CanBeNull]
         public ICSharpParameterDeclaration ParameterDeclaration { get; }

--- a/src/ReSharper.Structured.Logging/QuickFixes/ChangeContextualLoggerTypeFix.cs
+++ b/src/ReSharper.Structured.Logging/QuickFixes/ChangeContextualLoggerTypeFix.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 using JetBrains.Annotations;
 using JetBrains.Application.Progress;
@@ -172,65 +173,104 @@ namespace ReSharper.Structured.Logging.QuickFixes
                 return null;
             }
 
-            // Initializer: private readonly ILogger<B> _log = log;
             var initializer = ExpressionInitializerNavigator.GetByValue(expression);
-            if (initializer != null)
+
+            return initializer == null
+                ? FindAssignedDeclarationTypeUsage(expression)
+                : FindInitializedDeclarationTypeUsage(initializer);
+        }
+
+        /// <summary>
+        /// The declaration a logger initializes, which is the shape of a member declared and filled
+        /// in one go and of a variable initialised from a factory call.
+        /// </summary>
+        [CanBeNull]
+        private static ITypeUsage FindInitializedDeclarationTypeUsage([NotNull] IVariableInitializer initializer)
+        {
+            var initializedField = FieldDeclarationNavigator.GetByInitial(initializer);
+            if (initializedField != null)
             {
-                var initializedField = FieldDeclarationNavigator.GetByInitial(initializer);
-                if (initializedField != null)
-                {
-                    return HasSingleDeclarator(initializedField) ? initializedField.TypeUsage : null;
-                }
-
-                var initializedVariable = LocalVariableDeclarationNavigator.GetByInitial(initializer);
-                if (initializedVariable != null)
-                {
-                    // An implicitly typed variable already follows whatever the initializer returns
-                    return initializedVariable.IsVar || !HasSingleDeclarator(initializedVariable)
-                        ? null
-                        : initializedVariable.TypeUsage;
-                }
-
-                return PropertyDeclarationNavigator.GetByInitial(initializer)
-                    ?.TypeUsage;
+                return HasSingleDeclarator(initializedField) ? initializedField.TypeUsage : null;
             }
 
-            // Assignment: _log = log;
+            var initializedVariable = LocalVariableDeclarationNavigator.GetByInitial(initializer);
+            if (initializedVariable != null)
+            {
+                return GetRewritableVariableTypeUsage(initializedVariable);
+            }
+
+            return PropertyDeclarationNavigator.GetByInitial(initializer)
+                ?.TypeUsage;
+        }
+
+        /// <summary>
+        /// The declaration a logger is assigned to after it has been declared, which is how a
+        /// constructor fills a field and how a method fills a variable declared further up.
+        /// </summary>
+        [CanBeNull]
+        private ITypeUsage FindAssignedDeclarationTypeUsage([NotNull] ICSharpExpression expression)
+        {
             var assignment = AssignmentExpressionNavigator.GetBySource(expression);
             if (assignment == null || assignment.AssignmentType != AssignmentType.EQ)
             {
                 return null;
             }
 
-            var member = (assignment.Dest as IReferenceExpression)?.Reference.Resolve()
+            var target = (assignment.Dest as IReferenceExpression)?.Reference.Resolve()
                 .DeclaredElement;
-
-            // Guards against assigning the logger into a member of some other type.
-            if (member == null || !_expectedType.Equals((member as IClrDeclaredElement)?.GetContainingType()))
+            if (target == null)
             {
                 return null;
             }
 
-            foreach (var declaration in member.GetDeclarations())
+            // Guards against assigning the logger into a member of some other type. A variable needs
+            // no such guard, it belongs to the method the assignment sits in.
+            if (target is ITypeMember member && !_expectedType.Equals(member.GetContainingType()))
             {
-                // Never reach into another file - the quick fix only rewrites what the user can see.
-                if (declaration.GetSourceFile() != expression.GetSourceFile())
-                {
-                    continue;
-                }
-
-                if (declaration is IFieldDeclaration fieldDeclaration)
-                {
-                    return HasSingleDeclarator(fieldDeclaration) ? fieldDeclaration.TypeUsage : null;
-                }
-
-                if (declaration is IPropertyDeclaration propertyDeclaration)
-                {
-                    return propertyDeclaration.TypeUsage;
-                }
+                return null;
             }
 
-            return null;
+            // Never reach into another file - the quick fix only rewrites what the user can see.
+            var declaration = target.GetDeclarations()
+                .FirstOrDefault(d => d.GetSourceFile() == expression.GetSourceFile());
+
+            return declaration == null ? null : GetRewritableDeclarationTypeUsage(declaration);
+        }
+
+        /// <summary>
+        /// The type usage that can follow the logger, or <c>null</c> for the shapes that have to be
+        /// left alone: a parameter, whose signature this fix does not own, and a declaration sharing
+        /// its type with further declarators.
+        /// </summary>
+        [CanBeNull]
+        private static ITypeUsage GetRewritableDeclarationTypeUsage([NotNull] IDeclaration declaration)
+        {
+            if (declaration is IFieldDeclaration fieldDeclaration)
+            {
+                return HasSingleDeclarator(fieldDeclaration) ? fieldDeclaration.TypeUsage : null;
+            }
+
+            if (declaration is IPropertyDeclaration propertyDeclaration)
+            {
+                return propertyDeclaration.TypeUsage;
+            }
+
+            return declaration is ILocalVariableDeclaration variableDeclaration
+                ? GetRewritableVariableTypeUsage(variableDeclaration)
+                : null;
+        }
+
+        /// <summary>
+        /// An implicitly typed variable already follows whatever its initializer returns, so it has
+        /// no type argument of its own to rewrite.
+        /// </summary>
+        [CanBeNull]
+        private static ITypeUsage GetRewritableVariableTypeUsage(
+            [NotNull] ILocalVariableDeclaration variableDeclaration)
+        {
+            return variableDeclaration.IsVar || !HasSingleDeclarator(variableDeclaration)
+                ? null
+                : variableDeclaration.TypeUsage;
         }
 
         [CanBeNull]

--- a/src/ReSharper.Structured.Logging/QuickFixes/ChangeContextualLoggerTypeFix.cs
+++ b/src/ReSharper.Structured.Logging/QuickFixes/ChangeContextualLoggerTypeFix.cs
@@ -82,22 +82,46 @@ namespace ReSharper.Structured.Logging.QuickFixes
                 .FullName;
         }
 
-        private static bool HasSingleDeclarator([NotNull] IFieldDeclaration fieldDeclaration)
+        private static bool HasSingleDeclarator([NotNull] IMultipleDeclarationMember declarationMember)
         {
-            var multipleDeclaration = (fieldDeclaration as IMultipleDeclarationMember)?.MultipleDeclaration;
+            var multipleDeclaration = declarationMember.MultipleDeclaration;
 
             return multipleDeclaration == null || multipleDeclaration.Declarators.Count <= 1;
         }
 
         /// <summary>
-        /// Locates the type argument of every field or property the logger parameter is assigned to,
-        /// so that the type keeps compiling after the parameter type is changed.
+        /// Locates the type argument of every field, property or variable the logger is assigned to,
+        /// so that the type keeps compiling after the logger type is changed.
         /// </summary>
         [NotNull]
         private IList<ITypeUsage> FindAssignedMemberTypeArguments()
         {
             var result = new List<ITypeUsage>();
-            if (_parameterDeclaration == null || !_parameterDeclaration.IsValid())
+
+            // Only members logging the very same wrong type are rewritten. ILogger<T> is covariant,
+            // so an ILogger<object> member is legitimate and has to be left alone.
+            var wrongTypeName = GetContextTypeName(_typeArgument);
+            if (wrongTypeName == null)
+            {
+                return result;
+            }
+
+            // A ForContext<T>() or CreateLogger<T>() call has no parameter to walk from,
+            // the logger goes straight from the invocation into the member.
+            if (_parameterDeclaration == null)
+            {
+                var invocationTypeArgument = GetWrongLoggerTypeArgument(
+                    FindMemberTypeUsage(_typeArgument.GetContainingNode<IInvocationExpression>()),
+                    wrongTypeName);
+                if (invocationTypeArgument != null)
+                {
+                    result.Add(invocationTypeArgument);
+                }
+
+                return result;
+            }
+
+            if (!_parameterDeclaration.IsValid())
             {
                 return result;
             }
@@ -105,14 +129,6 @@ namespace ReSharper.Structured.Logging.QuickFixes
             var parameter = _parameterDeclaration.DeclaredElement;
             var typeDeclaration = _parameterDeclaration.GetContainingNode<ITypeDeclaration>();
             if (parameter == null || typeDeclaration == null)
-            {
-                return result;
-            }
-
-            // Only members logging the very same wrong type are rewritten. ILogger<T> is covariant,
-            // so an ILogger<object> member is legitimate and has to be left alone.
-            var wrongTypeName = GetContextTypeName(_typeArgument);
-            if (wrongTypeName == null)
             {
                 return result;
             }
@@ -143,11 +159,21 @@ namespace ReSharper.Structured.Logging.QuickFixes
             return result;
         }
 
+        /// <summary>
+        /// The declared type of the field, property or variable the expression is stored in, or
+        /// <c>null</c> when the value is consumed some other way - returned or passed as an argument,
+        /// for instance - where there is nothing that can be rewritten along with it.
+        /// </summary>
         [CanBeNull]
-        private ITypeUsage FindMemberTypeUsage([NotNull] IReferenceExpression referenceExpression)
+        private ITypeUsage FindMemberTypeUsage([CanBeNull] ICSharpExpression expression)
         {
-            // Primary constructor: private readonly ILogger<B> _log = log;
-            var initializer = ExpressionInitializerNavigator.GetByValue(referenceExpression);
+            if (expression == null)
+            {
+                return null;
+            }
+
+            // Initializer: private readonly ILogger<B> _log = log;
+            var initializer = ExpressionInitializerNavigator.GetByValue(expression);
             if (initializer != null)
             {
                 var initializedField = FieldDeclarationNavigator.GetByInitial(initializer);
@@ -156,12 +182,21 @@ namespace ReSharper.Structured.Logging.QuickFixes
                     return HasSingleDeclarator(initializedField) ? initializedField.TypeUsage : null;
                 }
 
+                var initializedVariable = LocalVariableDeclarationNavigator.GetByInitial(initializer);
+                if (initializedVariable != null)
+                {
+                    // An implicitly typed variable already follows whatever the initializer returns
+                    return initializedVariable.IsVar || !HasSingleDeclarator(initializedVariable)
+                        ? null
+                        : initializedVariable.TypeUsage;
+                }
+
                 return PropertyDeclarationNavigator.GetByInitial(initializer)
                     ?.TypeUsage;
             }
 
-            // Regular constructor: _log = log;
-            var assignment = AssignmentExpressionNavigator.GetBySource(referenceExpression);
+            // Assignment: _log = log;
+            var assignment = AssignmentExpressionNavigator.GetBySource(expression);
             if (assignment == null || assignment.AssignmentType != AssignmentType.EQ)
             {
                 return null;
@@ -179,7 +214,7 @@ namespace ReSharper.Structured.Logging.QuickFixes
             foreach (var declaration in member.GetDeclarations())
             {
                 // Never reach into another file - the quick fix only rewrites what the user can see.
-                if (declaration.GetSourceFile() != _parameterDeclaration.GetSourceFile())
+                if (declaration.GetSourceFile() != expression.GetSourceFile())
                 {
                     continue;
                 }

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftCorrectContextType.cs
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftCorrectContextType.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Logging;
+
+class A
+{
+    private readonly ILogger _log;
+
+    public A(ILoggerFactory loggerFactory)
+    {
+        _log = loggerFactory.CreateLogger<A>();
+    }
+}

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftCorrectContextType.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftCorrectContextType.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    private readonly ILogger _log;
+
+    public A(ILoggerFactory loggerFactory)
+    {
+        _log = loggerFactory.CreateLogger<A>();
+    }
+}
+
+---------------------------------------------------------

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftGenericTypeParameterIsIgnored.cs
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftGenericTypeParameterIsIgnored.cs
@@ -1,0 +1,9 @@
+using Microsoft.Extensions.Logging;
+
+static class A
+{
+    public static ILogger<T> Create<T>(ILoggerFactory loggerFactory)
+    {
+        return loggerFactory.CreateLogger<T>();
+    }
+}

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftGenericTypeParameterIsIgnored.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftGenericTypeParameterIsIgnored.cs.gold
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.Logging;
+
+static class A
+{
+    public static ILogger<T> Create<T>(ILoggerFactory loggerFactory)
+    {
+        return loggerFactory.CreateLogger<T>();
+    }
+}
+
+---------------------------------------------------------

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftWrongContextType.cs
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftWrongContextType.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.Logging;
+
+class A
+{
+    private readonly ILogger _log;
+
+    public A(ILoggerFactory loggerFactory)
+    {
+        _log = loggerFactory.CreateLogger<B>();
+    }
+}
+
+class B { }

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftWrongContextType.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftWrongContextType.cs.gold
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    private readonly ILogger _log;
+
+    public A(ILoggerFactory loggerFactory)
+    {
+        _log = |loggerFactory.CreateLogger<B>()|(0);
+    }
+}
+
+class B { }
+
+---------------------------------------------------------
+(0): ReSharper Warning: Incorrect type is used for contextual logger

--- a/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogCorrectContextType.cs
+++ b/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogCorrectContextType.cs
@@ -1,0 +1,6 @@
+using Serilog;
+
+class A
+{
+    private static readonly ILogger Logger = Log.ForContext<A>();
+}

--- a/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogCorrectContextType.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogCorrectContextType.cs.gold
@@ -1,0 +1,8 @@
+﻿using Serilog;
+
+class A
+{
+    private static readonly ILogger Logger = Log.ForContext<A>();
+}
+
+---------------------------------------------------------

--- a/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogWrongContextType.cs
+++ b/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogWrongContextType.cs
@@ -1,0 +1,8 @@
+using Serilog;
+
+class A
+{
+    private static readonly ILogger Logger = Log.ForContext<B>();
+}
+
+class B { }

--- a/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogWrongContextType.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogWrongContextType.cs.gold
@@ -1,0 +1,11 @@
+﻿using Serilog;
+
+class A
+{
+    private static readonly ILogger Logger = |Log.ForContext<B>()|(0);
+}
+
+class B { }
+
+---------------------------------------------------------
+(0): ReSharper Warning: Incorrect type is used for contextual logger

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryAssignedLocalVariable.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryAssignedLocalVariable.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory)
+    {
+        ILogger<B> log;
+        log = loggerFactory.CreateLogger<{caret}B>();
+    }
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryAssignedLocalVariable.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryAssignedLocalVariable.cs.gold
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory)
+    {
+        ILogger<A> log;
+        log = loggerFactory.CreateLogger<A{caret}>();
+    }
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryCovariantMemberIsNotChanged.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryCovariantMemberIsNotChanged.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    ILogger<object> _log;
+
+    public A(ILoggerFactory loggerFactory)
+    {
+        _log = loggerFactory.CreateLogger<{caret}B>();
+    }
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryCovariantMemberIsNotChanged.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryCovariantMemberIsNotChanged.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    ILogger<object> _log;
+
+    public A(ILoggerFactory loggerFactory)
+    {
+        _log = loggerFactory.CreateLogger<A{caret}>();
+    }
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryGenericMemberIsChanged.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryGenericMemberIsChanged.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    ILogger<B> _log;
+
+    public A(ILoggerFactory loggerFactory)
+    {
+        _log = loggerFactory.CreateLogger<{caret}B>();
+    }
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryGenericMemberIsChanged.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryGenericMemberIsChanged.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    ILogger<A> _log;
+
+    public A(ILoggerFactory loggerFactory)
+    {
+        _log = loggerFactory.CreateLogger<A{caret}>();
+    }
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryImplicitlyTypedLocalVariable.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryImplicitlyTypedLocalVariable.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory)
+    {
+        var log = loggerFactory.CreateLogger<{caret}B>();
+    }
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryImplicitlyTypedLocalVariable.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryImplicitlyTypedLocalVariable.cs.gold
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory)
+    {
+        var log = loggerFactory.CreateLogger<A{caret}>();
+    }
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryLocalVariable.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryLocalVariable.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory)
+    {
+        ILogger<B> log = loggerFactory.CreateLogger<{caret}B>();
+    }
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryLocalVariable.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryLocalVariable.cs.gold
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory)
+    {
+        ILogger<A> log = loggerFactory.CreateLogger<A{caret}>();
+    }
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryWrongContextType.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryWrongContextType.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    ILogger _log;
+
+    public A(ILoggerFactory loggerFactory)
+    {
+        _log = loggerFactory.CreateLogger<{caret}B>();
+    }
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryWrongContextType.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestMicrosoftFactoryWrongContextType.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    ILogger _log;
+
+    public A(ILoggerFactory loggerFactory)
+    {
+        _log = loggerFactory.CreateLogger<A{caret}>();
+    }
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestSerilogStaticLogWrongContextType.cs
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestSerilogStaticLogWrongContextType.cs
@@ -1,0 +1,8 @@
+﻿using Serilog;
+
+class A
+{
+    private static readonly ILogger ContextLogger = Log.ForContext<{caret}B>();
+}
+
+class B { }

--- a/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestSerilogStaticLogWrongContextType.cs.gold
+++ b/test/data/QuickFixes/ChangeContextualLoggerTypeFix/TestSerilogStaticLogWrongContextType.cs.gold
@@ -1,0 +1,8 @@
+﻿using Serilog;
+
+class A
+{
+    private static readonly ILogger ContextLogger = Log.ForContext<A{caret}>();
+}
+
+class B { }

--- a/test/src/Analyzer/ContextualLoggerMicrosoftFactoryAnalyzerTests.cs
+++ b/test/src/Analyzer/ContextualLoggerMicrosoftFactoryAnalyzerTests.cs
@@ -1,0 +1,18 @@
+using JetBrains.ReSharper.TestFramework;
+
+using NUnit.Framework;
+
+namespace ReSharper.Structured.Logging.Tests.Analyzer
+{
+    [TestNet60]
+    public class ContextualLoggerMicrosoftFactoryAnalyzerTests : MessageTemplateAnalyzerTestBase
+    {
+        protected override string SubPath => "ContextualLoggerMicrosoftFactory";
+
+        [Test] public void TestMicrosoftCorrectContextType() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftWrongContextType() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftGenericTypeParameterIsIgnored() => DoNamedTest2();
+    }
+}

--- a/test/src/Analyzer/ContextualLoggerSerilogFactoryAnalyzerTests.cs
+++ b/test/src/Analyzer/ContextualLoggerSerilogFactoryAnalyzerTests.cs
@@ -9,5 +9,9 @@ namespace ReSharper.Structured.Logging.Tests.Analyzer
         [Test] public void TestSerilogCorrectContextType() => DoNamedTest2();
 
         [Test] public void TestSerilogWrongContextType() => DoNamedTest2();
+
+        [Test] public void TestSerilogStaticLogCorrectContextType() => DoNamedTest2();
+
+        [Test] public void TestSerilogStaticLogWrongContextType() => DoNamedTest2();
     }
 }

--- a/test/src/QuickFixes/ChangeContextualLoggerTypeFixDotNet6Tests.cs
+++ b/test/src/QuickFixes/ChangeContextualLoggerTypeFixDotNet6Tests.cs
@@ -42,5 +42,7 @@ namespace ReSharper.Structured.Logging.Tests.QuickFixes
         [Test] public void TestMicrosoftFactoryLocalVariable() => DoNamedTest();
 
         [Test] public void TestMicrosoftFactoryImplicitlyTypedLocalVariable() => DoNamedTest();
+
+        [Test] public void TestMicrosoftFactoryAssignedLocalVariable() => DoNamedTest();
     }
 }

--- a/test/src/QuickFixes/ChangeContextualLoggerTypeFixDotNet6Tests.cs
+++ b/test/src/QuickFixes/ChangeContextualLoggerTypeFixDotNet6Tests.cs
@@ -32,5 +32,15 @@ namespace ReSharper.Structured.Logging.Tests.QuickFixes
         [Test] public void TestMicrosoftExpressionBodiedConstructor() => DoNamedTest();
 
         [Test] public void TestMicrosoftCovariantMemberIsNotChanged() => DoNamedTest();
+
+        [Test] public void TestMicrosoftFactoryWrongContextType() => DoNamedTest();
+
+        [Test] public void TestMicrosoftFactoryGenericMemberIsChanged() => DoNamedTest();
+
+        [Test] public void TestMicrosoftFactoryCovariantMemberIsNotChanged() => DoNamedTest();
+
+        [Test] public void TestMicrosoftFactoryLocalVariable() => DoNamedTest();
+
+        [Test] public void TestMicrosoftFactoryImplicitlyTypedLocalVariable() => DoNamedTest();
     }
 }

--- a/test/src/QuickFixes/ChangeContextualLoggerTypeFixTests.cs
+++ b/test/src/QuickFixes/ChangeContextualLoggerTypeFixTests.cs
@@ -9,5 +9,7 @@ namespace ReSharper.Structured.Logging.Tests.QuickFixes
         protected override string SubPath => "ChangeContextualLoggerTypeFix";
 
         [Test] public void TestSerilogWrongContextType() => DoNamedTest();
+
+        [Test] public void TestSerilogStaticLogWrongContextType() => DoNamedTest();
     }
 }


### PR DESCRIPTION
Closes #165.

The contextual logger check covered two ways of obtaining a logger and missed two equally common ones:

| Shape | Before | After |
| --- | --- | --- |
| `ILogger<T>` constructor parameter | flagged | flagged |
| `Serilog.ILogger.ForContext<T>()` | flagged | flagged |
| `Serilog.Log.ForContext<T>()` | missed | flagged |
| `ILoggerFactory.CreateLogger<T>()` | missed | flagged |

The static facade was missed because the FQN check required the containing type to be `Serilog.ILogger`, and `Serilog.Log` declares its own `ForContext<TSource>()`. Nothing looked at `Microsoft.Extensions.Logging.LoggerFactoryExtensions` at all.

Both new shapes report the existing `ContextualLoggerProblem` warning at the same configurable severity, with the same `Change contextual logger type to 'X'` quick fix.

## Changes

- `PsiExtensions.IsSerilogContextFactoryLogger` becomes `IsContextualLoggerFactoryMethod`, matching on `IClrTypeName` constants like the neighbouring helpers instead of an inline string comparison. The single-type-argument guard still excludes the overloads that name the category some other way (`ForContext(string, object)`, `CreateLogger(Type)`, and so on).
- `ContextualLoggerSerilogFactoryAnalyzer` is renamed `ContextualLoggerFactoryAnalyzer`, since it is no longer Serilog-specific. Source-only rename; nothing else referenced it.
- `ChangeContextualLoggerTypeFix` no longer emits non-compiling code. `ILogger<TCategoryName>` is covariant, so rewriting only `CreateLogger<B>()` left an `ILogger<A>` assigned to an `ILogger<B>` member. The factory path now rewrites the field, property or explicitly typed local the logger flows into, reusing the existing guard so `ILogger<object>` and `var` are left alone.
- A type-parameter argument is skipped: `ILogger<T> Create<T>(ILoggerFactory f) => f.CreateLogger<T>()` can never name its containing type. That false positive was already latent on the `ForContext<T>()` path.
- `rules/ContextualLoggerProblem.md` documents both new shapes.

## Worth flagging

**This will fire on deliberate cross-category loggers.** `loggerFactory.CreateLogger<Other>()` in a composition root is legitimate and now warns. Issue #165 anticipated this and asked for the same treatment as the existing warning rather than something stricter, so the configurable severity is the escape hatch — but it is the change most likely to draw feedback.

The quick fix still cannot repair every position: `return f.CreateLogger<B>();` or a logger passed straight as an argument get only the call rewritten. Same class of limitation the fix already had.

Not addressed here, out of scope for #165: `ContextualLoggerConstructorAnalyzer` has the same type-parameter false positive for `class A<T> { A(ILogger<T> log) }`.

## Validation

- `build.cmd Compile`, plus a `ReSharper.Structured.Logging.Rider.csproj` build — both clean, 0 warnings.
- `build.cmd Test` — 140/140 passing, up from 129. 11 new tests covering both new shapes, the covariant member that must not change, explicitly typed and `var` locals, and the generic-wrapper guard.
- The two new analyzer gold files were taken from the framework's actual output rather than written by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contextual logger analysis now supports Microsoft logger factory calls and static or instance Serilog context calls.
  * Warnings identify mismatched logger context types across additional logger creation patterns.
  * Quick-fixes now correct contextual logger types in fields, properties, and eligible explicitly typed local variables.

* **Bug Fixes**
  * Improved handling of generic, missing, and inferred logger types to reduce incorrect diagnostics.

* **Tests**
  * Added coverage for Microsoft and Serilog logger factories, context validation, and quick-fix scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->