### PR TITLE
Automate SDK updates and their releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,10 @@ on:
 
 concurrency:
   # A dispatched release gets a group to itself, keyed on the run, so that a push landing while it
-  # publishes cannot cancel it half way through. Push and pull request runs keep superseding theirs
+  # publishes cannot cancel it half way through. Pull request runs keep superseding theirs
   group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # A push to master can publish too, so those runs are left alone for the same reason
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -34,10 +35,48 @@ jobs:
 
     outputs:
       version: ${{ steps.version.outputs.value }}
+      publish: ${{ steps.publish-decision.outputs.value }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          # The publish decision below compares this commit against the one the push started from
+          fetch-depth: 0
+
+      # A new SDK is the only change that has to reach users as a new build, and it is what the SDK
+      # update workflow merges here, so an SdkVersion change landing on master is a release. Every
+      # other release stays a manual dispatch with the publish input
+      - name: Decide whether to publish
+        id: publish-decision
+        shell: bash
+        env:
+          DISPATCHED_PUBLISH: ${{ inputs.publish }}
+          PUSHED_FROM: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          read_sdk_version() {
+            sed -n 's:.*<SdkVersion>\(.*\)</SdkVersion>.*:\1:p'
+          }
+
+          publish=false
+
+          # Stripping the zeros empties the all-zero SHA that a branch creation reports, which has no
+          # Directory.Build.props to compare against
+          if [ "$DISPATCHED_PUBLISH" = "true" ]; then
+            publish=true
+          elif [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/master" ] && [ -n "${PUSHED_FROM//0/}" ]; then
+            previous=$(git show "$PUSHED_FROM:Directory.Build.props" 2>/dev/null | read_sdk_version || true)
+            current=$(read_sdk_version < Directory.Build.props)
+
+            if [ -n "$previous" ] && [ "$previous" != "$current" ]; then
+              echo "The JetBrains SDK went from $previous to $current, so this push is a release"
+              publish=true
+            fi
+          fi
+
+          echo "value=$publish" >> "$GITHUB_OUTPUT"
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v6
@@ -92,13 +131,13 @@ jobs:
         run: echo "value=$env:EXTENSION_VERSION" >> $env:GITHUB_OUTPUT
 
       - name: Publish ReSharper plugin
-        if: inputs.publish
+        if: steps.publish-decision.outputs.value == 'true'
         env:
           MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
         run: .\build.cmd PublishReSharperPlugin --configuration Release
 
       - name: Publish Rider plugin
-        if: inputs.publish
+        if: steps.publish-decision.outputs.value == 'true'
         env:
           MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
         run: .\build.cmd PublishRiderPlugin --configuration Release --is-rider-host
@@ -106,7 +145,7 @@ jobs:
   release:
     name: Create GitHub release
     needs: build
-    if: inputs.publish
+    if: needs.build.outputs.publish == 'true'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/sdk-update.yml
+++ b/.github/workflows/sdk-update.yml
@@ -1,0 +1,113 @@
+name: SDK update
+
+on:
+  schedule:
+    # Daily, so that an EAP is picked up the morning after JetBrains publishes it
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+    inputs:
+      sdk-version:
+        description: Adopt this SDK version instead of the one the wave policy picks
+        type: string
+
+concurrency:
+  group: sdk-update
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_NOLOGO: true
+
+jobs:
+  propose:
+    name: Propose SDK update
+    if: github.repository == 'olsh/resharper-structured-logging'
+    runs-on: ubuntu-latest
+
+    steps:
+      # The pull request has to run the Build workflow, and one opened with the built in token never
+      # triggers a workflow, so the branch and the pull request go through a personal access token
+      - name: Check the automation token
+        env:
+          AUTOMATION_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
+        run: |
+          if [ -z "$AUTOMATION_TOKEN" ]; then
+            echo "::error::The AUTOMATION_TOKEN secret is missing. Create a fine grained personal access token for this repository with read and write access to contents and pull requests."
+            exit 1
+          fi
+
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.AUTOMATION_TOKEN }}
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Look for a newer SDK
+        id: sdk
+        env:
+          SDK_VERSION_OVERRIDE: ${{ inputs.sdk-version }}
+        run: |
+          if [ -n "$SDK_VERSION_OVERRIDE" ]; then
+            ./build.sh UpdateSdkVersion --sdk-version-override "$SDK_VERSION_OVERRIDE"
+          else
+            ./build.sh UpdateSdkVersion
+          fi
+
+      - name: Open the update pull request
+        if: steps.sdk.outputs.sdk-update-available == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          SDK_VERSION: ${{ steps.sdk.outputs.sdk-version }}
+          PREVIOUS_SDK_VERSION: ${{ steps.sdk.outputs.previous-sdk-version }}
+        run: |
+          set -euo pipefail
+
+          branch="sdk-update/$SDK_VERSION"
+
+          if [ -n "$(gh pr list --state open --head "$branch" --json number --jq '.[].number')" ]; then
+            echo "A pull request for $SDK_VERSION is already open"
+            exit 0
+          fi
+
+          # A wave whose build never went green must not keep the next one from being proposed
+          for number in $(gh pr list --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("sdk-update/")) | .number'); do
+            gh pr close "$number" --comment "Superseded by the update to $SDK_VERSION." --delete-branch
+          done
+
+          cat > "$RUNNER_TEMP/pull-request-body.md" <<BODY
+          The JetBrains SDK moved from \`$PREVIOUS_SDK_VERSION\` to [\`$SDK_VERSION\`](https://www.nuget.org/packages/JetBrains.ReSharper.SDK/$SDK_VERSION).
+
+          Merging this publishes. An \`SdkVersion\` change landing on \`master\` runs the release path of the Build workflow, which pushes both plugins to JetBrains Marketplace and creates the GitHub release, and auto-merge is already enabled here.
+
+          When the build is red, the usual suspects are:
+
+          - [ ] binding redirects in \`test/src/app.config\` that the new SDK needs
+          - [ ] \`.gold\` expectations that moved with the SDK's rendering
+          - [ ] SDK API breaks in the analyzers and the quick fixes
+          - [ ] \`build.gradle\`, the IntelliJ Platform Gradle Plugin or the Gradle wrapper
+          BODY
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git switch --create "$branch"
+          git commit --all --message "Bump JetBrains SDK to $SDK_VERSION"
+          # Nothing but this workflow writes to sdk-update/*, and any leftover branch has no open
+          # pull request left by this point
+          git push --force --set-upstream origin "$branch"
+
+          gh pr create \
+            --base master \
+            --head "$branch" \
+            --title "Bump JetBrains SDK to $SDK_VERSION" \
+            --body-file "$RUNNER_TEMP/pull-request-body.md"
+
+          gh pr merge "$branch" --auto --squash --delete-branch

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -31,7 +31,8 @@
         "PublishReSharperPlugin",
         "PublishRiderPlugin",
         "RunIde",
-        "Test"
+        "Test",
+        "UpdateSdkVersion"
       ]
     },
     "Verbosity": {
@@ -117,6 +118,10 @@
         },
         "RunIdeSolution": {
           "type": "string"
+        },
+        "SdkVersionOverride": {
+          "type": "string",
+          "description": "Adopt this SDK version instead of the one the wave policy picks"
         }
       }
     },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,17 +13,26 @@ Run commands from the repository root:
 - `build.cmd Pack`: compile and create the ReSharper NuGet package; this is the default NUKE target.
 - `build.cmd PackRiderPlugin --is-rider-host`: build and package the Rider plugin through Gradle.
 - `build.cmd RunIde --is-rider-host [--run-ide-solution <path>]`: launch a sandboxed Rider with the plugin installed for manual testing; the optional solution path is opened on start, for example `--run-ide-solution test/manual/Issue130/Issue130.slnx`.
+- `build.cmd UpdateSdkVersion [--sdk-version-override <version>]`: adopt a newer JetBrains SDK in `Directory.Build.props`; see "Adopting a new SDK".
 - `dotnet sln ReSharper.Structured.Logging.slnx list`: verify that solution project links resolve.
 
 The build requires a compatible .NET SDK; Rider packaging also requires a JDK 17 or newer to run Gradle. The JDK that the Rider build itself compiles against is derived from the target Rider version and provisioned automatically by the Foojay toolchain resolver configured in `settings.gradle`, so it does not need to be installed by hand. Generated output appears in `bin/`, `gradle-build/`, and repository-root package files and must not be committed.
 
 ## Releasing
 
-Releases are published from the `Build` workflow, not from a tag. Run it manually with the `publish` input enabled (`gh workflow run build.yml --ref master -f publish=true`) and it packs both plugins, pushes the ReSharper `.nupkg` and the Rider `.zip` to JetBrains Marketplace, then creates the git tag and GitHub release. Publishing needs the `JETBRAINS_MARKETPLACE_TOKEN` repository secret, a permanent token from <https://plugins.jetbrains.com/author/me/tokens>.
+Releases are published from the `Build` workflow, not from a tag. It publishes when the `publish` input is enabled on a manual run (`gh workflow run build.yml --ref master -f publish=true`), and also when a push to `master` changes `SdkVersion` in `Directory.Build.props`, which is how an SDK update ships itself. Either way it packs both plugins, pushes the ReSharper `.nupkg` and the Rider `.zip` to JetBrains Marketplace, then creates the git tag and GitHub release. Publishing needs the `JETBRAINS_MARKETPLACE_TOKEN` repository secret, a permanent token from <https://plugins.jetbrains.com/author/me/tokens>.
 
 The published version and the tag are `<SdkVersion>.<workflow run number>`, where `SdkVersion` comes from `Directory.Build.props`. Marketplace rejects a version it already has, so a failed publish must be re-dispatched rather than re-run, and Marketplace moderation means a successful run only says the update was uploaded. An EAP `SdkVersion` suffix routes the Rider plugin to the `eap` channel and marks the GitHub release as a prerelease.
 
 The corresponding NUKE targets are `PublishReSharperPlugin` and `PublishRiderPlugin --is-rider-host`; both read the token from the `MARKETPLACE_TOKEN` environment variable and refuse to run without it.
+
+## Adopting a new SDK
+
+The `SDK update` workflow polls nuget.org daily and proposes the bump itself. `build.cmd UpdateSdkVersion` is what it runs: the target reads the versions published for all four SDK packages, keeps only those every one of them has, and picks a target under the wave policy. While the adopted version is stable only a higher wave qualifies, because a same-wave patch is already covered by the `Wave` dependency range the package declares; once it is a prerelease the whole train is followed, `eap01` through `rc01` to the stable release that closes the wave. `--sdk-version-override <version>` adopts a specific version instead, which is the way to take a same-wave patch.
+
+The workflow then commits the bump to `sdk-update/<version>`, opens a pull request with auto-merge enabled, and lets `Build and test` decide. Green merges to `master`, which publishes; red leaves the pull request open, which is the normal outcome for a wave change. Expect to fix binding redirects in `test/src/app.config`, `.gold` expectations, SDK API breaks, and sometimes `build.gradle` and the Gradle wrapper. A stale red pull request is closed as superseded when the next version comes along.
+
+Opening that pull request needs the `AUTOMATION_TOKEN` repository secret, a fine-grained personal access token for this repository with read and write access to contents and pull requests. A pull request opened with the built-in `GITHUB_TOKEN` never triggers a workflow, so `Build and test` would never report and auto-merge would wait forever. To drive the flow without waiting for JetBrains, dispatch it with `-f sdk-version=<version>`.
 
 ## Development References
 

--- a/ReSharper.Structured.Logging.slnx
+++ b/ReSharper.Structured.Logging.slnx
@@ -17,6 +17,7 @@
         <File Path=".github/dependabot.yml"/>
         <File Path=".github/workflows/build.yml"/>
         <File Path=".github/workflows/dependabot-auto-merge.yml"/>
+        <File Path=".github/workflows/sdk-update.yml"/>
         <File Path=".gitignore"/>
         <File Path="build.gradle"/>
         <File Path="Directory.Build.props"/>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,8 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using System.Xml.Linq;
+
+using NuGet.Versioning;
 
 using Nuke.Common;
 using Nuke.Common.CI;
@@ -62,12 +67,25 @@ class Build : NukeBuild
 
     [Parameter] readonly AbsolutePath RunIdeSolution;
 
+    [Parameter("Adopt this SDK version instead of the one the wave policy picks")]
+    readonly string SdkVersionOverride;
+
     [LocalPath("./gradlew.bat")] readonly Tool Gradle;
 
     [NuGetPackage(
         packageId: "dotnet-cleanup",
         packageExecutable: "DotnetCleanup.dll")]
     readonly Tool DotNetCleanup;
+
+    // Every project pins its SDK package to $(SdkVersion), and JetBrains does not always push the
+    // four of them at the same minute, so a version counts as available only once all of them have it
+    static readonly string[] SdkPackageIds =
+    {
+        "jetbrains.resharper.sdk",
+        "jetbrains.rider.sdk",
+        "jetbrains.resharper.sdk.tests",
+        "jetbrains.rider.sdk.tests",
+    };
 
     string RiderPackagePath => RootDirectory / $"rider-structured-logging-{ExtensionVersion}.zip";
 
@@ -79,10 +97,17 @@ class Build : NukeBuild
     {
         get
         {
-            var productVersion = SdkVersionWithoutSuffix.TrimEnd('.', '0');
+            // A zero patch is dropped, so 2025.1.0 is 2025.1 there, but 2026.2.1 stays as it is
+            var productVersion = SdkVersionWithoutSuffix.EndsWith(".0", StringComparison.Ordinal)
+                ? SdkVersionWithoutSuffix.Substring(0, SdkVersionWithoutSuffix.Length - ".0".Length)
+                : SdkVersionWithoutSuffix;
+
             if (!string.IsNullOrEmpty(SdkVersionSuffix))
             {
-                productVersion += $"{SdkVersionSuffix.Replace("0", string.Empty).ToUpper()}-SNAPSHOT";
+                // -eap01 is -EAP1 there. The leading zeros go one number at a time, so that -eap10
+                // does not collapse onto -EAP1
+                var suffix = Regex.Replace(SdkVersionSuffix, @"\d+", x => int.Parse(x.Value).ToString());
+                productVersion += $"{suffix.ToUpperInvariant()}-SNAPSHOT";
             }
 
             return productVersion;
@@ -256,6 +281,92 @@ class Build : NukeBuild
                 });
         });
 
+    Target UpdateSdkVersion => _ => _
+        .Executes(async () =>
+        {
+            var availableVersions = await GetPublishedSdkVersions();
+            var currentVersion = NuGetVersion.Parse(SdkVersion);
+
+            NuGetVersion targetVersion;
+            if (SdkVersionOverride != null)
+            {
+                var requestedVersion = NuGetVersion.Parse(SdkVersionOverride);
+                targetVersion = availableVersions
+                    .FirstOrDefault(x => x.Equals(requestedVersion))
+                    .NotNull($"{SdkVersionOverride} is not published for every JetBrains SDK package");
+            }
+            else
+            {
+                targetVersion = SelectSdkUpdate(currentVersion, availableVersions);
+            }
+
+            if (targetVersion == null || targetVersion.Equals(currentVersion))
+            {
+                Serilog.Log.Information("The JetBrains SDK {Version} is up to date", SdkVersion);
+                PublishGitHubOutput("sdk-update-available", "false");
+
+                return;
+            }
+
+            var propsFile = RootDirectory / "Directory.Build.props";
+            // A regex rather than XDocument.Save, so that the MSBuild namespace declaration, the
+            // attribute order and the comment in the file all survive untouched
+            propsFile.WriteAllText(Regex.Replace(
+                propsFile.ReadAllText(),
+                "<SdkVersion>[^<]*</SdkVersion>",
+                $"<SdkVersion>{targetVersion}</SdkVersion>"));
+
+            Serilog.Log.Information("Updated the JetBrains SDK from {Current} to {Target}", SdkVersion, targetVersion);
+            ReportSummary(_ => _.AddPair("SDK", $"{SdkVersion} -> {targetVersion}"));
+
+            PublishGitHubOutput("sdk-update-available", "true");
+            PublishGitHubOutput("sdk-version", targetVersion.ToString());
+            PublishGitHubOutput("previous-sdk-version", SdkVersion);
+        });
+
+    static async Task<IReadOnlyCollection<NuGetVersion>> GetPublishedSdkVersions()
+    {
+        using var client = new HttpClient();
+
+        HashSet<NuGetVersion> versions = null;
+        foreach (var packageId in SdkPackageIds)
+        {
+            var index = await client.GetStringAsync($"https://api.nuget.org/v3-flatcontainer/{packageId}/index.json");
+
+            using var document = JsonDocument.Parse(index);
+            var published = document.RootElement
+                .GetProperty("versions")
+                .EnumerateArray()
+                .Select(x => NuGetVersion.Parse(x.GetString()))
+                .ToList();
+
+            if (versions == null)
+            {
+                versions = new HashSet<NuGetVersion>(published, VersionComparer.Default);
+            }
+            else
+            {
+                versions.IntersectWith(published);
+            }
+        }
+
+        return versions;
+    }
+
+    // A same wave patch is already covered by the Wave dependency range the package declares, so it
+    // is not worth a release; the next wave is, and it shows up as an EAP first. Once the adopted
+    // version is a prerelease the whole train is followed instead: eap01 -> rc01 -> the stable release
+    static NuGetVersion SelectSdkUpdate(NuGetVersion currentVersion, IEnumerable<NuGetVersion> availableVersions)
+    {
+        return availableVersions
+            .Where(x => x > currentVersion)
+            .Where(x => currentVersion.IsPrerelease
+                        || x.Major > currentVersion.Major
+                        || (x.Major == currentVersion.Major && x.Minor > currentVersion.Minor))
+            .OrderBy(x => x)
+            .LastOrDefault();
+    }
+
     // Replaces AppVeyor's UpdateBuildVersion, which used to display the extension version on the
     // build page. GitHub Actions evaluates run-name before any step runs, so the version cannot go
     // there; it goes to the job summary instead, and to the workflow environment so that the upload
@@ -283,5 +394,18 @@ class Build : NukeBuild
         {
             summaryFile.AppendAllLines(new[] { $"### Version `{ExtensionVersion}`" });
         }
+    }
+
+    // Hands a value to the later steps of the same job, which is how the SDK update workflow learns
+    // what UpdateSdkVersion decided. Outside of GitHub Actions there is nowhere to write it
+    static void PublishGitHubOutput(string name, string value)
+    {
+        var outputFile = (AbsolutePath)GetVariable("GITHUB_OUTPUT");
+        if (outputFile == null)
+        {
+            return;
+        }
+
+        outputFile.AppendAllLines(new[] { $"{name}={value}" });
     }
 }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -38,7 +38,7 @@ class Build : NukeBuild
             .Value;
         SdkVersion.NotNull("Unable to detect SDK version");
 
-        var versionMatch = Regex.Match(SdkVersion, @"(?<version>[\d\.]+)(?<suffix>-.*)?");
+        var versionMatch = Regex.Match(SdkVersion, @"(?<version>[\d\.]+)(?<suffix>-.*)?", RegexOptions.None, RegexTimeout);
 
         SdkVersionWithoutSuffix = versionMatch.Groups["version"]
             .ToString();
@@ -48,7 +48,7 @@ class Build : NukeBuild
         ExtensionVersion = GitHubActions == null
             ? SdkVersion
             : $"{versionMatch.Groups["version"]}.{GitHubActions.RunNumber}{versionMatch.Groups["suffix"]}";
-        var sdkMatch = Regex.Match(SdkVersion, @"\d{2}(\d{2}).(\d).*");
+        var sdkMatch = Regex.Match(SdkVersion, @"\d{2}(\d{2}).(\d).*", RegexOptions.None, RegexTimeout);
         WaveMajorVersion = int.Parse(sdkMatch.Groups[1]
             .Value + sdkMatch.Groups[2]
             .Value);
@@ -76,6 +76,10 @@ class Build : NukeBuild
         packageId: "dotnet-cleanup",
         packageExecutable: "DotnetCleanup.dll")]
     readonly Tool DotNetCleanup;
+
+    // Every regex here runs over a version string of a couple of dozen characters, so the bound is
+    // only ever reached by a runaway
+    static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
 
     // Every project pins its SDK package to $(SdkVersion), and JetBrains does not always push the
     // four of them at the same minute, so a version counts as available only once all of them have it
@@ -106,7 +110,12 @@ class Build : NukeBuild
             {
                 // -eap01 is -EAP1 there. The leading zeros go one number at a time, so that -eap10
                 // does not collapse onto -EAP1
-                var suffix = Regex.Replace(SdkVersionSuffix, @"\d+", x => int.Parse(x.Value).ToString());
+                var suffix = Regex.Replace(
+                    SdkVersionSuffix,
+                    @"\d+",
+                    x => int.Parse(x.Value).ToString(),
+                    RegexOptions.None,
+                    RegexTimeout);
                 productVersion += $"{suffix.ToUpperInvariant()}-SNAPSHOT";
             }
 
@@ -314,7 +323,9 @@ class Build : NukeBuild
             propsFile.WriteAllText(Regex.Replace(
                 propsFile.ReadAllText(),
                 "<SdkVersion>[^<]*</SdkVersion>",
-                $"<SdkVersion>{targetVersion}</SdkVersion>"));
+                $"<SdkVersion>{targetVersion}</SdkVersion>",
+                RegexOptions.None,
+                RegexTimeout));
 
             Serilog.Log.Information("Updated the JetBrains SDK from {Current} to {Target}", SdkVersion, targetVersion);
             ReportSummary(_ => _.AddPair("SDK", $"{SdkVersion} -> {targetVersion}"));


### PR DESCRIPTION
A new JetBrains SDK is the only recurring release trigger this repository has, and adopting one is entirely manual today: notice the release, edit `SdkVersion`, fix what broke, merge, then dispatch `build.yml` with `publish=true`. Nothing watches for it either — Dependabot's NuGet ecosystem is scoped to `/build/`, and the SDK packages are pinned through `Version="$(SdkVersion)"`, an MSBuild indirection it cannot resolve.

This makes the whole path automatic. A scheduled job finds the new SDK, the existing `Build` workflow proves it on a pull request, and green merges to `master` and ships both plugins to Marketplace. Red leaves the pull request open, which is the normal outcome for a wave change.

## `UpdateSdkVersion` target

Reads the versions published for all four `$(SdkVersion)` packages, keeps only those every one of them has, and orders them with `NuGetVersion` — available already through the existing `NuGet.Packaging` reference, so no new dependency. `Directory.Build.props` is rewritten by regex rather than `XDocument.Save` so the MSBuild namespace and the comment survive.

The wave policy: while the adopted version is stable, only a higher wave qualifies, because a same-wave patch is already covered by the `Wave` dependency range the package declares. Once it is a prerelease the whole train is followed, `eap01` through `rc01` to the stable release that closes the wave. `--sdk-version-override` bypasses it, which is how to take a same-wave patch.

## Releases ride the merge

A push to `master` that changes `SdkVersion` now publishes, so the bump ships itself without a second dispatch. `workflow_dispatch -f publish=true` is unchanged and stays the recovery path for a half-failed publish. `cancel-in-progress` is now limited to pull requests, since a publishing master push must not be cancelled half way through.

## Two latent bugs in `RiderProductVersion`

Both would have produced an unresolvable Rider coordinate on an unattended EAP release. `Replace("0", "")` stripped every zero, mapping `-eap10` onto `-EAP1` and colliding with `-eap01`; EAP numbering already reaches `eap09` on the current wave. `TrimEnd('.', '0')` trimmed a character set, so `2026.2.10` would have become `2026.2.1`.

## Before this can run

Needs an `AUTOMATION_TOKEN` repository secret: a fine-grained personal access token for this repository with read and write access to contents and pull requests. A pull request opened with the built-in `GITHUB_TOKEN` never triggers a workflow, so `Build and test` would never report and auto-merge would wait forever. The workflow fails with an explicit annotation until the secret exists.

## Validation

- `build.cmd Test --configuration Release` — 167/167
- `build.cmd Test --configuration Release --is-rider-host` — 167/167
- `build.cmd Pack --configuration Release` and `build.cmd PackRiderPlugin --configuration Release --is-rider-host`
- `UpdateSdkVersion` from `2026.2.1` reports up to date; from `2026.1.0` and from `2026.2.0-eap05` both pick `2026.2.1`; `--sdk-version-override 2026.2.0-eap09` takes it verbatim; `9999.9.9` fails as not published for every package
- `RiderProductVersion` against the compiled property: `2025.1.0-eap02 → 2025.1-EAP2-SNAPSHOT` and `2026.2.1 → 2026.2.1` unchanged, `2026.3.0-eap10 → 2026.3-EAP10-SNAPSHOT` and `2026.2.10 → 2026.2.10` fixed
- The publish decision simulated across eight event shapes; every ambiguous one (missing before-SHA, branch creation, non-master push) falls back to not publishing
- The pull request step dry-run against stubbed `gh` and `git`, covering the body, the already-open exit and the supersede path

After merging, `gh workflow run sdk-update.yml -f sdk-version=<version>` drives the flow end to end without waiting for JetBrains. That publishes a real release on merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added scheduled and manual checks for JetBrains SDK updates.
  - SDK updates can be selected automatically or supplied as a specific version.
  - Eligible updates can generate and maintain an upgrade pull request with automatic merging enabled.
  - Releases can publish automatically when SDK versions change on the main branch.
  - Added support for updating SDK versions through the build tooling.

- **Documentation**
  - Added guidance for SDK updates, release publishing, EAP channels, marketplace publishing, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->