### PR TITLE
Bump JetBrains SDK to 2026.3.0-eap01

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SdkVersion>2026.2.1</SdkVersion>
+    <SdkVersion>2026.3.0-eap01</SdkVersion>
   </PropertyGroup>
   <!-- https://jetbrains.slack.com/archives/CBZ36NH7C/p1628090127002200 -->
   <PropertyGroup>


### PR DESCRIPTION
The JetBrains SDK moved from `2026.2.1` to [`2026.3.0-eap01`](https://www.nuget.org/packages/JetBrains.ReSharper.SDK/2026.3.0-eap01).

Merging this publishes. An `SdkVersion` change landing on `master` runs the release path of the Build workflow, which pushes both plugins to JetBrains Marketplace and creates the GitHub release, and auto-merge is already enabled here.

When the build is red, the usual suspects are:

- [ ] binding redirects in `test/src/app.config` that the new SDK needs
- [ ] `.gold` expectations that moved with the SDK's rendering
- [ ] SDK API breaks in the analyzers and the quick fixes
- [ ] `build.gradle`, the IntelliJ Platform Gradle Plugin or the Gradle wrapper


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to use the 2026.3.0 early access SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->