### PR TITLE
Fix the deprecated DynamicBundle constructor and verify the Rider plugin in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,8 +104,21 @@ jobs:
       - name: Test Rider plugin
         run: .\build.cmd Test --configuration Release --is-rider-host
 
-      - name: Pack Rider plugin
-        run: .\build.cmd PackRiderPlugin --configuration Release --is-rider-host
+      # VerifyRiderPlugin depends on PackRiderPlugin, so this packs and verifies in one NUKE
+      # run. Keeping them as separate steps would enter the packaging target twice. Running it
+      # before the uploads and the publish steps is what keeps a plugin that fails
+      # verification from reaching Marketplace
+      - name: Pack and verify Rider plugin
+        run: .\build.cmd VerifyRiderPlugin --configuration Release --is-rider-host
+
+      # The verifier report only reaches the log at Debug level, so keep a readable copy
+      - name: Upload plugin verifier report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: plugin-verifier-report-${{ env.EXTENSION_VERSION }}
+          path: gradle-build/reports/pluginVerifier/
+          if-no-files-found: warn
 
       - name: Upload ReSharper package
         uses: actions/upload-artifact@v7

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -32,7 +32,8 @@
         "PublishRiderPlugin",
         "RunIde",
         "Test",
-        "UpdateSdkVersion"
+        "UpdateSdkVersion",
+        "VerifyRiderPlugin"
       ]
     },
     "Verbosity": {

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,27 @@ dependencies {
 }
 
 intellijPlatform {
+    pluginVerification {
+        // failureLevel is left at its convention, so the build fails on compatibility problems,
+        // internal API and override-only API. Deprecated API is reported rather than fatal: it is
+        // a warning, not a break, and failing on it would hold a release and turn every sdk-update
+        // pull request red as soon as JetBrains deprecates anything. The verifier prints its
+        // verdict to the build log and writes the report uploaded by the workflow
+
+        // The plugin ID predates these rules and is what Marketplace already has, so it cannot be
+        // changed without orphaning every installed copy. Marketplace grandfathers long-existing
+        // plugins; the standalone verifier does not, and without this it rejects the plugin as
+        // structurally invalid and verifies nothing at all
+        freeArgs = ['-mute', 'ForbiddenPluginIdPrefix,TemplateWordInPluginId']
+
+        ides {
+            // The Rider the plugin was just built against, which is also the one it ships for.
+            // Anything else would download a second multi-gigabyte distribution the runner has no
+            // room for, and 'recommended' skips the EAP builds this needs to cover
+            current()
+        }
+    }
+
     publishing {
         token    = providers.environmentVariable('PUBLISH_TOKEN')
         channels = [PluginChannel]

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -226,6 +226,27 @@ class Build : NukeBuild
             PublishExtensionVersion();
         });
 
+    // The Kotlin compiler already warns about deprecated platform API, but every Gradle line is
+    // logged at Debug, so the warning sits among hundreds of others and nobody reads it. Marketplace
+    // was the first thing to report it, and by then the plugin had shipped. This fails the build
+    Target VerifyRiderPlugin => _ => _
+        .DependsOn(PackRiderPlugin)
+        .Requires(() => IsRiderHost)
+        .Executes(() =>
+        {
+            Gradle(
+                $"verifyPlugin -PPluginVersion={ExtensionVersion} -PProductVersion={RiderProductVersion} -PDotNetOutputDirectory={OutputDirectory} -PDotNetProjectName={ProjectName}",
+                logger:
+                (_, s) =>
+                {
+                    // Gradle writes warnings to stderr
+                    // By default logger will write stderr as errors
+                    // Keep Gradle warnings from being reported as CI build errors
+                    // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
+                    Serilog.Log.Debug(s);
+                });
+        });
+
     Target PublishReSharperPlugin => _ => _
         .DependsOn(Pack)
         .Requires(() => !IsRiderHost)

--- a/src/rider/main/kotlin/com/jetbrains/rider/settings/StructuredLoggingBundle.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/settings/StructuredLoggingBundle.kt
@@ -5,7 +5,7 @@ import org.jetbrains.annotations.Nls
 import org.jetbrains.annotations.NonNls
 import org.jetbrains.annotations.PropertyKey
 
-class StructuredLoggingBundle : DynamicBundle(BUNDLE) {
+class StructuredLoggingBundle : DynamicBundle(StructuredLoggingBundle::class.java, BUNDLE) {
     companion object {
         @NonNls
         private const val BUNDLE = "messages.StructuredLoggingBundle"


### PR DESCRIPTION
Marketplace verification of `2026.3.0.76-eap01` reported *Compatible. 1 usage of deprecated API* for Rider 2026.3-EAP1 (263.3889.92).

The API is `DynamicBundle(String)`, used by `StructuredLoggingBundle`. The Kotlin compiler had already warned about it in the run that published that build:

```
w: .../StructuredLoggingBundle.kt:8:33 'constructor(p0: String): DynamicBundle' is deprecated. Deprecated in Java.
```

Nothing acted on it. Every Gradle line goes through the NUKE logger at Debug, and that run logged 711 `[DBG]` lines, so the warning was there and invisible. Since an `SdkVersion` change on `master` publishes automatically, Marketplace was the first thing to report it.

## Changes

**Verification** — configure the plugin verifier and run it from a new `VerifyRiderPlugin` NUKE target, in the same step as packaging (which it depends on) and before the uploads and both publish steps, so a plugin that fails verification never reaches Marketplace.

`failureLevel` stays at its convention: the build fails on compatibility problems, internal API and override-only API, and only *reports* deprecated API. A deprecation is a warning, not a break, and failing on it would hold a release and turn every `sdk-update` PR red as soon as JetBrains deprecates anything. The verdict goes to the build log and the full report is uploaded as an artifact.

`ides { current() }` verifies against the Rider the plugin was just built against. `recommended()` would pull extra IDEs and skip EAPs — exactly the case that failed here — and any explicit version means a second multi-gigabyte download the runner has no room for (see `build.yml:86-88`).

**The fix** — pass the bundle class so the non-deprecated `DynamicBundle(Class<?>, String)` overload is selected. That constructor already exists in 2026.2.1, so this is not tied to the 2026.3 SDK.

## The plugin ID has to be muted

The verifier rejects the plugin outright as structurally invalid:

```
The plugin ID 'com.intellij.resharper.StructuredLogging' has a prefix 'com.intellij' that is
not allowed / should not include the word 'intellij' / 'resharper'.
Scheduled verifications (0)
```

That ID is what Marketplace already has and cannot change without orphaning every installed copy. Marketplace grandfathers long-existing plugins; the standalone verifier does not, which is why Marketplace verified this build fine while the verifier would not read it at all. Hence `freeArgs = ['-mute', 'ForbiddenPluginIdPrefix,TemplateWordInPluginId']`.

## Validation

Commits were pushed in stages so the verification could be proven rather than assumed:

| Run | State | Result |
|---|---|---|
| [34145237551](https://github.com/olsh/resharper-structured-logging/actions/runs/34145237551) | pre-`-mute` | `Scheduled verifications (0)` — verified nothing |
| [34147427270](https://github.com/olsh/resharper-structured-logging/actions/runs/34147427270) | `-mute`, no fix | `Compatible. 1 usage of deprecated API` against `RD-263.3889.92` — the same verdict Marketplace gave, naming `DynamicBundle.<init>(String)` in `StructuredLoggingBundle.<init>()` |
| [34149745688](https://github.com/olsh/resharper-structured-logging/actions/runs/34149745688) | + fix | green — `Compatible`, no deprecated usages, compiler warning gone |

Those middle two ran while deprecated API was still a failure level; it now reports instead, so an equivalent finding would appear in the log and the uploaded report without stopping the build.

## Note

`2026.3.0.76-eap01` is already on Marketplace and is *compatible* — a deprecated API usage is a warning, not a break. This ships with the next release; the published version needs no re-push.
