### PR TITLE
Only report a contextual logger that stays in its own type

### DIFF
--- a/rules/ContextualLoggerProblem.md
+++ b/rules/ContextualLoggerProblem.md
@@ -111,3 +111,34 @@ class A
 
 class B { }
 ```
+
+The rule covers the logger a type keeps for itself. A logger built on behalf of somebody else - handed to a constructor, returned from a factory method, registered in a container - is named after that somebody, so it is not reported:
+
+```csharp
+class Worker
+{
+	public Worker(ILogger<Worker> logger)
+	{
+	}
+}
+
+static class WorkerFactory
+{
+	public static Worker Create(ILoggerFactory loggerFactory)
+	{
+		return new Worker(loggerFactory.CreateLogger<Worker>());
+	}
+}
+```
+
+```csharp
+static class WorkerLoggerFactory
+{
+	public static ILogger<Worker> Create(ILoggerFactory loggerFactory)
+	{
+		return loggerFactory.CreateLogger<Worker>();
+	}
+}
+
+class Worker { }
+```

--- a/src/ReSharper.Structured.Logging/Analyzer/ContextualLoggerFactoryAnalyzer.cs
+++ b/src/ReSharper.Structured.Logging/Analyzer/ContextualLoggerFactoryAnalyzer.cs
@@ -8,10 +8,15 @@ using ReSharper.Structured.Logging.Highlighting;
 
 namespace ReSharper.Structured.Logging.Analyzer
 {
-    [ElementProblemAnalyzer(typeof(IInvocationExpression))]
+    [ElementProblemAnalyzer(
+        typeof(IInvocationExpression),
+        HighlightingTypes = new[] { typeof(ContextualLoggerWarning) })]
     public class ContextualLoggerFactoryAnalyzer : ElementProblemAnalyzer<IInvocationExpression>
     {
-        protected override void Run(IInvocationExpression element, ElementProblemAnalyzerData data, IHighlightingConsumer consumer)
+        protected override void Run(
+            IInvocationExpression element,
+            ElementProblemAnalyzerData data,
+            IHighlightingConsumer consumer)
         {
             if (!element.IsContextualLoggerFactoryMethod())
             {
@@ -36,6 +41,13 @@ namespace ReSharper.Structured.Logging.Analyzer
             if (contextType.GetScalarType()
                     ?.GetClrName()
                     .FullName == containingNode.CLRName)
+            {
+                return;
+            }
+
+            // A composition root builds loggers for the types it wires up, so its own type would be
+            // the wrong context there. Only a logger that stays behind is this type's logger.
+            if (!element.IsOwnLoggerOfContainingType(containingNode))
             {
                 return;
             }

--- a/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
+++ b/src/ReSharper.Structured.Logging/Extensions/PsiExtensions.cs
@@ -404,6 +404,236 @@ namespace ReSharper.Structured.Logging.Extensions
         }
 
         /// <summary>
+        /// Reports whether the logger the call produces ends up being the containing type's own logger.
+        /// A logger that leaves the type - returned, handed to a constructor or a method, stored on some
+        /// other object - was built on behalf of somebody else, which is what a factory method or a
+        /// composition root does, and there the context type is meant to name that somebody.
+        /// </summary>
+        public static bool IsOwnLoggerOfContainingType(
+            [NotNull] this IInvocationExpression invocationExpression,
+            [NotNull] ITypeDeclaration typeDeclaration)
+        {
+            return StaysInContainingType(invocationExpression, typeDeclaration, null);
+        }
+
+        /// <summary>
+        /// The three shapes that keep a logger where it was built: it initializes a member or a local, it
+        /// is assigned to one, or it is spent on the spot as the qualifier of a further call. Anything
+        /// else - an argument, a return, an object initializer, a lambda body - hands it to somebody
+        /// else, so an unrecognized shape deliberately answers no: a missed warning beats a false one.
+        /// </summary>
+        private static bool StaysInContainingType(
+            [NotNull] ICSharpExpression expression,
+            [NotNull] ITypeDeclaration typeDeclaration,
+            [CanBeNull] HashSet<IDeclaredElement> visitedVariables)
+        {
+            var value = GetConsumedExpression(expression);
+
+            var initializer = ExpressionInitializerNavigator.GetByValue(value);
+            if (initializer != null)
+            {
+                if (FieldDeclarationNavigator.GetByInitial(initializer) != null
+                    || PropertyDeclarationNavigator.GetByInitial(initializer) != null)
+                {
+                    return true;
+                }
+
+                var variableDeclaration = LocalVariableDeclarationNavigator.GetByInitial(initializer);
+
+                return variableDeclaration != null
+                       && EveryReadStaysInContainingType(
+                           variableDeclaration.DeclaredElement,
+                           typeDeclaration,
+                           visitedVariables);
+            }
+
+            var assignment = AssignmentExpressionNavigator.GetBySource(value);
+            if (assignment != null)
+            {
+                return IsStoredInContainingType(assignment, typeDeclaration, visitedVariables);
+            }
+
+            return ReferenceExpressionNavigator.GetByQualifierExpression(value) != null;
+        }
+
+        /// <summary>
+        /// Climbs to the expression that is actually consumed. Parentheses, a cast, the null forgiving
+        /// operator, the branches of a conditional and the operands of ?? all pass the very same logger
+        /// on, and so does a chained call handing back a logger of the same type: in a chain it is the
+        /// last call that decides where the logger goes.
+        /// </summary>
+        [NotNull]
+        private static ICSharpExpression GetConsumedExpression([NotNull] ICSharpExpression expression)
+        {
+            while (true)
+            {
+                var parent = GetValuePreservingParent(expression);
+                if (parent == null)
+                {
+                    return expression;
+                }
+
+                expression = parent;
+            }
+        }
+
+        [CanBeNull]
+        private static ICSharpExpression GetValuePreservingParent([NotNull] ICSharpExpression expression)
+        {
+            var parenthesized = ParenthesizedExpressionNavigator.GetByExpression(expression);
+            if (parenthesized != null)
+            {
+                return parenthesized;
+            }
+
+            var cast = CastExpressionNavigator.GetByOp(expression);
+            if (cast != null)
+            {
+                return cast;
+            }
+
+            var suppressed = SuppressNullableWarningExpressionNavigator.GetByOperand(expression);
+            if (suppressed != null)
+            {
+                return suppressed;
+            }
+
+            var conditional = ConditionalTernaryExpressionNavigator.GetByAnyBranch(expression);
+            if (conditional != null)
+            {
+                return conditional;
+            }
+
+            var nullCoalescing = NullCoalescingExpressionNavigator.GetByAnyOperand(expression);
+            if (nullCoalescing != null)
+            {
+                return nullCoalescing;
+            }
+
+            return GetChainedLoggerCall(expression);
+        }
+
+        /// <summary>
+        /// The call written on top of this one when it hands back a logger of the same type. Comparing
+        /// the types is what tells the Serilog ForContext("Job", id) that continues the chain from the
+        /// Information(...) that spends it.
+        /// </summary>
+        [CanBeNull]
+        private static IInvocationExpression GetChainedLoggerCall([NotNull] ICSharpExpression expression)
+        {
+            var qualifiedReference = ReferenceExpressionNavigator.GetByQualifierExpression(expression);
+            if (qualifiedReference == null)
+            {
+                return null;
+            }
+
+            var chainedCall = InvocationExpressionNavigator.GetByInvokedExpression(qualifiedReference);
+
+            return chainedCall != null && Equals(chainedCall.Type(), expression.Type()) ? chainedCall : null;
+        }
+
+        /// <summary>
+        /// Whether an assignment parks the logger inside the containing type. A member of another type
+        /// takes the logger away exactly like a constructor argument does; a local keeps it here only
+        /// for as long as nothing reading it back carries it out.
+        /// </summary>
+        private static bool IsStoredInContainingType(
+            [NotNull] IAssignmentExpression assignment,
+            [NotNull] ITypeDeclaration typeDeclaration,
+            [CanBeNull] HashSet<IDeclaredElement> visitedVariables)
+        {
+            // ??= fills a member the way = does, the arithmetic compound ones cannot apply to a logger
+            if (assignment.AssignmentType != AssignmentType.EQ
+                && assignment.AssignmentType != AssignmentType.DOUBLE_QUEST_EQ)
+            {
+                return false;
+            }
+
+            var target = (assignment.Dest as IReferenceExpression)?.Reference.Resolve()
+                .DeclaredElement;
+            if (target is ITypeMember member)
+            {
+                return Equals(member.GetContainingType(), typeDeclaration.DeclaredElement);
+            }
+
+            return target is ILocalVariable localVariable
+                   && EveryReadStaysInContainingType(localVariable, typeDeclaration, visitedVariables);
+        }
+
+        /// <summary>
+        /// Whether every read of the variable keeps the logger inside the containing type. The reads are
+        /// found by walking the function the variable lives in, because an element problem analyzer has
+        /// no search engine at hand; the writes are left out, otherwise the very assignment that led
+        /// here would count as a read carrying the logger away.
+        /// </summary>
+        private static bool EveryReadStaysInContainingType(
+            [CanBeNull] IDeclaredElement variable,
+            [NotNull] ITypeDeclaration typeDeclaration,
+            [CanBeNull] HashSet<IDeclaredElement> visitedVariables)
+        {
+            if (variable == null)
+            {
+                return false;
+            }
+
+            // A pair such as first = second; second = first; would otherwise never settle
+            var visited = visitedVariables ?? new HashSet<IDeclaredElement>();
+            if (!visited.Add(variable))
+            {
+                return true;
+            }
+
+            var declaration = variable.GetDeclarations()
+                .FirstOrDefault();
+            if (declaration == null)
+            {
+                return false;
+            }
+
+            // A local cannot be read outside the function it is declared in; one declared in a lambda
+            // sitting in a member initializer has no function declaration to narrow the walk down to.
+            var scope = (ITreeNode)declaration.GetContainingNode<ICSharpFunctionDeclaration>()
+                        ?? typeDeclaration;
+            foreach (var referenceExpression in scope.Descendants<IReferenceExpression>())
+            {
+                if (IsReadOf(referenceExpression, variable)
+                    && !StaysInContainingType(referenceExpression, typeDeclaration, visited))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Whether the reference reads the variable rather than merely naming it as the target of a
+        /// plain assignment. Leaving the stores out is what keeps the very assignment that led here
+        /// from counting as a read that carries the logger away.
+        /// </summary>
+        private static bool IsReadOf(
+            [NotNull] IReferenceExpression referenceExpression,
+            [NotNull] IDeclaredElement variable)
+        {
+            // The cheap name check first, so that only the candidates are actually resolved
+            if (referenceExpression.NameIdentifier?.Name != variable.ShortName)
+            {
+                return false;
+            }
+
+            if (!variable.Equals(
+                    referenceExpression.Reference.Resolve()
+                        .DeclaredElement))
+            {
+                return false;
+            }
+
+            var write = AssignmentExpressionNavigator.GetByDest(referenceExpression);
+
+            return write == null || write.AssignmentType != AssignmentType.EQ;
+        }
+
+        /// <summary>
         /// LoggerMessage.Define and DefineScope bind template holes to generic type parameters,
         /// so the arguments that follow the template are not the values of those holes.
         /// </summary>

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftEscapingLocalVariableIsIgnored.cs
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftEscapingLocalVariableIsIgnored.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Logging;
+
+class Worker
+{
+    public Worker(ILogger<Worker> logger)
+    {
+    }
+}
+
+class A
+{
+    public Worker Create(ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger<Worker>();
+
+        return new Worker(logger);
+    }
+}

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftEscapingLocalVariableIsIgnored.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftEscapingLocalVariableIsIgnored.cs.gold
@@ -1,0 +1,20 @@
+﻿using Microsoft.Extensions.Logging;
+
+class Worker
+{
+    public Worker(ILogger<Worker> logger)
+    {
+    }
+}
+
+class A
+{
+    public Worker Create(ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger<Worker>();
+
+        return new Worker(logger);
+    }
+}
+
+---------------------------------------------------------

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftExpressionBodiedFactoryIsIgnored.cs
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftExpressionBodiedFactoryIsIgnored.cs
@@ -1,0 +1,8 @@
+using Microsoft.Extensions.Logging;
+
+static class WorkerLoggerFactory
+{
+    public static ILogger<Worker> Create(ILoggerFactory loggerFactory) => loggerFactory.CreateLogger<Worker>();
+}
+
+class Worker { }

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftExpressionBodiedFactoryIsIgnored.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftExpressionBodiedFactoryIsIgnored.cs.gold
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.Logging;
+
+static class WorkerLoggerFactory
+{
+    public static ILogger<Worker> Create(ILoggerFactory loggerFactory) => loggerFactory.CreateLogger<Worker>();
+}
+
+class Worker { }
+
+---------------------------------------------------------

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLocalVariableIsReported.cs
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLocalVariableIsReported.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Logging;
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory)
+    {
+        var log = loggerFactory.CreateLogger<B>();
+    }
+}
+
+class B { }

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLocalVariableIsReported.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLocalVariableIsReported.cs.gold
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory)
+    {
+        var log = |loggerFactory.CreateLogger<B>()|(0);
+    }
+}
+
+class B { }
+
+---------------------------------------------------------
+(0): ReSharper Warning: Incorrect type is used for contextual logger

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLoggerAssignedToOtherTypeIsIgnored.cs
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLoggerAssignedToOtherTypeIsIgnored.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Logging;
+
+class Worker
+{
+    public ILogger Logger { get; set; }
+}
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory, Worker worker)
+    {
+        worker.Logger = loggerFactory.CreateLogger<Worker>();
+    }
+}

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLoggerAssignedToOtherTypeIsIgnored.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLoggerAssignedToOtherTypeIsIgnored.cs.gold
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.Logging;
+
+class Worker
+{
+    public ILogger Logger { get; set; }
+}
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory, Worker worker)
+    {
+        worker.Logger = loggerFactory.CreateLogger<Worker>();
+    }
+}
+
+---------------------------------------------------------

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLoggerInObjectInitializerIsIgnored.cs
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLoggerInObjectInitializerIsIgnored.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Logging;
+
+class Worker
+{
+    public ILogger Logger { get; set; }
+}
+
+class A
+{
+    public Worker Create(ILoggerFactory loggerFactory)
+    {
+        return new Worker { Logger = loggerFactory.CreateLogger<Worker>() };
+    }
+}

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLoggerInObjectInitializerIsIgnored.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLoggerInObjectInitializerIsIgnored.cs.gold
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.Logging;
+
+class Worker
+{
+    public ILogger Logger { get; set; }
+}
+
+class A
+{
+    public Worker Create(ILoggerFactory loggerFactory)
+    {
+        return new Worker { Logger = loggerFactory.CreateLogger<Worker>() };
+    }
+}
+
+---------------------------------------------------------

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLoggerPassedToConstructorIsIgnored.cs
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLoggerPassedToConstructorIsIgnored.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.Logging;
+
+class Worker
+{
+    public Worker(ILogger<Worker> logger)
+    {
+    }
+}
+
+static class WorkerFactory
+{
+    public static Worker Create(ILoggerFactory loggerFactory)
+    {
+        return new Worker(loggerFactory.CreateLogger<Worker>());
+    }
+}

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLoggerPassedToConstructorIsIgnored.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftLoggerPassedToConstructorIsIgnored.cs.gold
@@ -1,0 +1,18 @@
+﻿using Microsoft.Extensions.Logging;
+
+class Worker
+{
+    public Worker(ILogger<Worker> logger)
+    {
+    }
+}
+
+static class WorkerFactory
+{
+    public static Worker Create(ILoggerFactory loggerFactory)
+    {
+        return new Worker(loggerFactory.CreateLogger<Worker>());
+    }
+}
+
+---------------------------------------------------------

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftReassignedEscapingLocalVariableIsIgnored.cs
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftReassignedEscapingLocalVariableIsIgnored.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Logging;
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory, Worker worker)
+    {
+        ILogger log = loggerFactory.CreateLogger<Worker>();
+        log = loggerFactory.CreateLogger<B>();
+
+        worker.Attach(log);
+    }
+}
+
+class Worker
+{
+    public void Attach(ILogger logger)
+    {
+    }
+}
+
+class B { }

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftReassignedEscapingLocalVariableIsIgnored.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftReassignedEscapingLocalVariableIsIgnored.cs.gold
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory, Worker worker)
+    {
+        ILogger log = loggerFactory.CreateLogger<Worker>();
+        log = loggerFactory.CreateLogger<B>();
+
+        worker.Attach(log);
+    }
+}
+
+class Worker
+{
+    public void Attach(ILogger logger)
+    {
+    }
+}
+
+class B { }
+
+---------------------------------------------------------

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftReassignedLocalVariableIsReported.cs
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftReassignedLocalVariableIsReported.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Logging;
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory)
+    {
+        ILogger log = loggerFactory.CreateLogger<B>();
+        log = loggerFactory.CreateLogger<A>();
+
+        log.LogInformation("Configured");
+    }
+}
+
+class B { }

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftReassignedLocalVariableIsReported.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftReassignedLocalVariableIsReported.cs.gold
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory)
+    {
+        ILogger log = |loggerFactory.CreateLogger<B>()|(0);
+        log = loggerFactory.CreateLogger<A>();
+
+        log.LogInformation("Configured");
+    }
+}
+
+class B { }
+
+---------------------------------------------------------
+(0): ReSharper Warning: Incorrect type is used for contextual logger

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftReturnedLoggerIsIgnored.cs
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftReturnedLoggerIsIgnored.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Logging;
+
+static class WorkerLoggerFactory
+{
+    public static ILogger<Worker> Create(ILoggerFactory loggerFactory)
+    {
+        return loggerFactory.CreateLogger<Worker>();
+    }
+}
+
+class Worker { }

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftReturnedLoggerIsIgnored.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftReturnedLoggerIsIgnored.cs.gold
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Logging;
+
+static class WorkerLoggerFactory
+{
+    public static ILogger<Worker> Create(ILoggerFactory loggerFactory)
+    {
+        return loggerFactory.CreateLogger<Worker>();
+    }
+}
+
+class Worker { }
+
+---------------------------------------------------------

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftUsedLocalVariableIsReported.cs
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftUsedLocalVariableIsReported.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.Logging;
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory)
+    {
+        var log = loggerFactory.CreateLogger<B>();
+
+        log.LogInformation("Configured");
+    }
+}
+
+class B { }

--- a/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftUsedLocalVariableIsReported.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerMicrosoftFactory/MicrosoftUsedLocalVariableIsReported.cs.gold
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.Logging;
+
+class A
+{
+    public void Configure(ILoggerFactory loggerFactory)
+    {
+        var log = |loggerFactory.CreateLogger<B>()|(0);
+
+        log.LogInformation("Configured");
+    }
+}
+
+class B { }
+
+---------------------------------------------------------
+(0): ReSharper Warning: Incorrect type is used for contextual logger

--- a/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogChainedCallIsReported.cs
+++ b/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogChainedCallIsReported.cs
@@ -1,0 +1,8 @@
+using Serilog;
+
+class A
+{
+    private static readonly ILogger Logger = Log.ForContext<B>().ForContext("JobId", 1);
+}
+
+class B { }

--- a/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogChainedCallIsReported.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogChainedCallIsReported.cs.gold
@@ -1,0 +1,11 @@
+﻿using Serilog;
+
+class A
+{
+    private static readonly ILogger Logger = |Log.ForContext<B>()|(0).ForContext("JobId", 1);
+}
+
+class B { }
+
+---------------------------------------------------------
+(0): ReSharper Warning: Incorrect type is used for contextual logger

--- a/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogInlineCallIsReported.cs
+++ b/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogInlineCallIsReported.cs
@@ -1,0 +1,11 @@
+using Serilog;
+
+class A
+{
+    public void Run()
+    {
+        Log.ForContext<B>().Information("Started");
+    }
+}
+
+class B { }

--- a/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogInlineCallIsReported.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogInlineCallIsReported.cs.gold
@@ -1,0 +1,14 @@
+﻿using Serilog;
+
+class A
+{
+    public void Run()
+    {
+        |Log.ForContext<B>()|(0).Information("Started");
+    }
+}
+
+class B { }
+
+---------------------------------------------------------
+(0): ReSharper Warning: Incorrect type is used for contextual logger

--- a/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogPassedToConstructorIsIgnored.cs
+++ b/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogPassedToConstructorIsIgnored.cs
@@ -1,0 +1,16 @@
+using Serilog;
+
+class Worker
+{
+    public Worker(ILogger logger)
+    {
+    }
+}
+
+static class WorkerFactory
+{
+    public static Worker Create()
+    {
+        return new Worker(Log.ForContext<Worker>());
+    }
+}

--- a/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogPassedToConstructorIsIgnored.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogPassedToConstructorIsIgnored.cs.gold
@@ -1,0 +1,18 @@
+﻿using Serilog;
+
+class Worker
+{
+    public Worker(ILogger logger)
+    {
+    }
+}
+
+static class WorkerFactory
+{
+    public static Worker Create()
+    {
+        return new Worker(Log.ForContext<Worker>());
+    }
+}
+
+---------------------------------------------------------

--- a/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogPropertyIsReported.cs
+++ b/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogPropertyIsReported.cs
@@ -1,0 +1,8 @@
+using Serilog;
+
+class A
+{
+    private static ILogger Logger { get; } = Log.ForContext<B>();
+}
+
+class B { }

--- a/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogPropertyIsReported.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogPropertyIsReported.cs.gold
@@ -1,0 +1,11 @@
+﻿using Serilog;
+
+class A
+{
+    private static ILogger Logger { get; } = |Log.ForContext<B>()|(0);
+}
+
+class B { }
+
+---------------------------------------------------------
+(0): ReSharper Warning: Incorrect type is used for contextual logger

--- a/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogReturnedChainIsIgnored.cs
+++ b/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogReturnedChainIsIgnored.cs
@@ -1,0 +1,11 @@
+using Serilog;
+
+static class WorkerLoggerFactory
+{
+    public static ILogger Create(int jobId)
+    {
+        return Log.ForContext<Worker>().ForContext("JobId", jobId);
+    }
+}
+
+class Worker { }

--- a/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogReturnedChainIsIgnored.cs.gold
+++ b/test/data/Analyzers/ContextualLoggerSerilogFactory/SerilogStaticLogReturnedChainIsIgnored.cs.gold
@@ -1,0 +1,13 @@
+﻿using Serilog;
+
+static class WorkerLoggerFactory
+{
+    public static ILogger Create(int jobId)
+    {
+        return Log.ForContext<Worker>().ForContext("JobId", jobId);
+    }
+}
+
+class Worker { }
+
+---------------------------------------------------------

--- a/test/src/Analyzer/ContextualLoggerMicrosoftFactoryAnalyzerTests.cs
+++ b/test/src/Analyzer/ContextualLoggerMicrosoftFactoryAnalyzerTests.cs
@@ -30,5 +30,9 @@ namespace ReSharper.Structured.Logging.Tests.Analyzer
         [Test] public void TestMicrosoftLocalVariableIsReported() => DoNamedTest2();
 
         [Test] public void TestMicrosoftUsedLocalVariableIsReported() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftReassignedLocalVariableIsReported() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftReassignedEscapingLocalVariableIsIgnored() => DoNamedTest2();
     }
 }

--- a/test/src/Analyzer/ContextualLoggerMicrosoftFactoryAnalyzerTests.cs
+++ b/test/src/Analyzer/ContextualLoggerMicrosoftFactoryAnalyzerTests.cs
@@ -14,5 +14,21 @@ namespace ReSharper.Structured.Logging.Tests.Analyzer
         [Test] public void TestMicrosoftWrongContextType() => DoNamedTest2();
 
         [Test] public void TestMicrosoftGenericTypeParameterIsIgnored() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftLoggerPassedToConstructorIsIgnored() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftReturnedLoggerIsIgnored() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftExpressionBodiedFactoryIsIgnored() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftLoggerAssignedToOtherTypeIsIgnored() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftLoggerInObjectInitializerIsIgnored() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftEscapingLocalVariableIsIgnored() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftLocalVariableIsReported() => DoNamedTest2();
+
+        [Test] public void TestMicrosoftUsedLocalVariableIsReported() => DoNamedTest2();
     }
 }

--- a/test/src/Analyzer/ContextualLoggerSerilogFactoryAnalyzerTests.cs
+++ b/test/src/Analyzer/ContextualLoggerSerilogFactoryAnalyzerTests.cs
@@ -13,5 +13,15 @@ namespace ReSharper.Structured.Logging.Tests.Analyzer
         [Test] public void TestSerilogStaticLogCorrectContextType() => DoNamedTest2();
 
         [Test] public void TestSerilogStaticLogWrongContextType() => DoNamedTest2();
+
+        [Test] public void TestSerilogStaticLogPassedToConstructorIsIgnored() => DoNamedTest2();
+
+        [Test] public void TestSerilogStaticLogReturnedChainIsIgnored() => DoNamedTest2();
+
+        [Test] public void TestSerilogStaticLogChainedCallIsReported() => DoNamedTest2();
+
+        [Test] public void TestSerilogStaticLogInlineCallIsReported() => DoNamedTest2();
+
+        [Test] public void TestSerilogStaticLogPropertyIsReported() => DoNamedTest2();
     }
 }


### PR DESCRIPTION
Fixes #182.

## The problem

`ContextualLoggerFactoryAnalyzer`, added in #176, compares the type argument of `CreateLogger<T>()` and `ForContext<T>()` against the containing type and warns on any mismatch. That premise holds for constructor injection, where a class receives its own logger, but not for a factory call: DI registrations, factory methods, `Program.cs` wiring and test fixtures all legitimately build a logger *for the type they construct*.

```csharp
public static class WorkerFactory
{
    public static Worker Create(ILoggerFactory loggerFactory)
        => new Worker(loggerFactory.CreateLogger<Worker>());  // warned, and the quick fix rewrote it to <WorkerFactory>
}
```

In a DI-heavy solution that flags nearly every `CreateLogger<T>` call site, all of them correct. Since both contextual logger analyzers share the `ContextualLoggerProblem` severity id, the only workaround was suppressing the inspection wholesale, which also loses the constructor injection check.

#165 already anticipated this: *"`CreateLogger<T>()` on a factory is sometimes deliberately used to build a logger for another category."*

## The change

A new `IsOwnLoggerOfContainingType` gate in `PsiExtensions`, applied as the last check in the factory analyzer so the cheap checks still run first. The warning is reported only when the logger stays inside the containing type:

| Shape | Verdict |
| --- | --- |
| Initializer of a field or property of the containing type | report |
| Assigned (`=`, `??=`) to a field or property of the containing type | report |
| Initializer of, or assigned to, a local whose every read also stays | report |
| Qualifier of a further call, `Log.ForContext<B>().Information(…)` | report |
| Argument to a method or constructor call | skip |
| Returned, or the body of a lambda or expression-bodied method | skip |
| Assigned into a member of another type, object initializers included | skip |
| Stored in a local whose value later escapes | skip |

The classifier is a whitelist, so a shape it does not recognize is not reported: a missed warning beats a false one.

The walk climbs through parentheses, casts, the null forgiving operator, ternary branches and `??` operands first, and follows a chained call only while it hands back a logger of the same type. That type comparison is what separates `ForContext("Job", id)`, which continues the chain, from `Information(…)`, which spends it.

Top-level statements needed no handling: `ITopLevelCode` is not an `ITypeDeclaration`, so `GetContainingNode<ITypeDeclaration>()` was already `null` there.

`ContextualLoggerConstructorAnalyzer`, `ChangeContextualLoggerTypeFix` and the severity id are untouched. The analyzer now declares `HighlightingTypes`, so the daemon can skip it entirely when the inspection is off, which matters now that it does real work.

### Why the quick fix walk was not reused

`ChangeContextualLoggerTypeFix` has a superficially similar walk, but it answers "which type usage may I rewrite" and is deliberately conservative: it returns `null` for `var` locals, multi-declarator fields and declarations in another file. Each of those `null`s means *rewrite less*; reused in the analyzer each would silently mean *do not warn*. `TestMicrosoftFactoryImplicitlyTypedLocalVariable` is exactly a case the fix declines to rewrite but the analyzer must still flag. The gate also recurses transitively where the fix stops at one hop.

## Validation

- `build.cmd Test`: **180/180 passing**, 167 existing plus 13 new analyzer cases.
- **No existing `.gold` file changed** - additions only. That is the real check here: quick fix availability derives from the highlighting, so the six `TestMicrosoftFactory*` cases and the four existing factory analyzer cases passing unmodified is what shows the gate did not narrow anything it should not have.
- `build.cmd Compile`: 0 warnings.

New coverage, split between `ContextualLoggerMicrosoftFactory` and `ContextualLoggerSerilogFactory`: the issue repro, returned loggers, expression-bodied factories, assignment into another type, object initializers and an escaping local on the negative side; unused and used locals, a chained call, an inline call and a property initializer on the positive side, so the change cannot quietly stop reporting the real defect.

## Known limitations

Both conservative, both false negatives:

- A logger assigned to a `protected` field declared on a **base** class is not reported, because `GetContainingType()` is the base rather than the containing type.
- `_log = flag switch { true => f.CreateLogger<B>(), _ => null };` is not reported; switch expressions are not in the value-preserving set.

## Follow-up, not in this PR

`ChangeContextualLoggerTypeFix.FindMemberTypeUsage` starts from the raw invocation, so for `_log = cond ? f.CreateLogger<B>() : null;` it rewrites the type argument but leaves `ILogger<B> _log` behind. Pre-existing rather than a regression - the analyzer reported that shape before this change too - and starting it from the new `GetConsumedExpression` would close it, but that changes fix behaviour with no failing test behind it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Contextual logger analysis now reports only loggers retained and used by their containing type.
  - Loggers passed to constructors, returned by factories, assigned to another type, or used in object initializers are no longer incorrectly flagged.
  - Improved tracking through local variables, reassignment, chained calls, and expression-bodied factories.

- **Tests**
  - Added coverage for Microsoft logging and Serilog scenarios, including valid warnings and ignored logger flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->