### PR TITLE
Allow releasing to the stable wave while master tracks an EAP SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,13 @@ on:
         description: Publish the packages to JetBrains Marketplace and create the GitHub release
         type: boolean
         default: false
+      # While master follows the EAP train, this is how a fix reaches the current stable wave: the
+      # packages, the Wave range, the Rider build and the Marketplace channel all follow the override,
+      # so no maintenance branch is needed. Deliberately without a default, so that every other run
+      # evaluates it to an empty string
+      sdk-version:
+        description: Build against this SDK version instead of the one in Directory.Build.props
+        type: string
 
 concurrency:
   # A dispatched release gets a group to itself, keyed on the run, so that a push landing while it
@@ -33,6 +40,12 @@ jobs:
     permissions:
       contents: read
 
+    # NUKE resolves its SdkVersionOverride parameter from this, so every build.cmd step below picks it
+    # up without repeating it on each command line. Every non-dispatch run gets an empty string, which
+    # NUKE reads as unset, so it builds against Directory.Build.props exactly as it does today
+    env:
+      SDK_VERSION_OVERRIDE: ${{ inputs.sdk-version }}
+
     outputs:
       version: ${{ steps.version.outputs.value }}
       publish: ${{ steps.publish-decision.outputs.value }}
@@ -46,7 +59,9 @@ jobs:
 
       # A new SDK is the only change that has to reach users as a new build, and it is what the SDK
       # update workflow merges here, so an SdkVersion change landing on master is a release. Every
-      # other release stays a manual dispatch with the publish input
+      # other release stays a manual dispatch with the publish input.
+      # The sdk-version input never rewrites Directory.Build.props, so the comparison below keeps
+      # meaning exactly what it means today, and a dispatched run never reaches it
       - name: Decide whether to publish
         id: publish-decision
         shell: bash
@@ -167,6 +182,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           VERSION: ${{ needs.build.outputs.version }}
+          SDK_VERSION_OVERRIDE: ${{ inputs.sdk-version }}
         run: |
           if [ -z "$VERSION" ]; then
             echo "::error::The build job did not report an extension version"
@@ -179,4 +195,13 @@ jobs:
             *) prerelease= ;;
           esac
 
-          gh release create "$VERSION" --target "$GITHUB_SHA" --title "$VERSION" --generate-notes $prerelease
+          # An overridden SDK leaves Directory.Build.props alone, so the tagged commit no longer records
+          # what the packages were built against and the notes have to. --notes is prepended to the
+          # generated ones rather than replacing them
+          notes=()
+          if [ -n "$SDK_VERSION_OVERRIDE" ]; then
+            notes=(--notes "Built against the JetBrains SDK \`$SDK_VERSION_OVERRIDE\`, which is not the one this commit declares in \`Directory.Build.props\`.")
+          fi
+
+          gh release create "$VERSION" --target "$GITHUB_SHA" --title "$VERSION" \
+            --generate-notes "${notes[@]}" $prerelease

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -122,7 +122,7 @@
         },
         "SdkVersionOverride": {
           "type": "string",
-          "description": "Adopt this SDK version instead of the one the wave policy picks"
+          "description": "Use this SDK version instead of the one in Directory.Build.props"
         }
       }
     },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ The corresponding NUKE targets are `PublishReSharperPlugin` and `PublishRiderPlu
 
 `master` follows the prerelease train for most of a cycle, and the whole build derives its identity from that one `SdkVersion` — the version, the `Wave` range the package declares, the Rider `productVersion` and the Marketplace channel — so a release cut from it reaches EAP users only. The `sdk-version` input overrides the SDK for a single run without touching the file:
 
-```
+```bash
 gh workflow run build.yml --ref master -f publish=true -f sdk-version=2026.2.1
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Run commands from the repository root:
 - `build.cmd PackRiderPlugin --is-rider-host`: build and package the Rider plugin through Gradle.
 - `build.cmd RunIde --is-rider-host [--run-ide-solution <path>]`: launch a sandboxed Rider with the plugin installed for manual testing; the optional solution path is opened on start, for example `--run-ide-solution test/manual/Issue130/Issue130.slnx`.
 - `build.cmd UpdateSdkVersion [--sdk-version-override <version>]`: adopt a newer JetBrains SDK in `Directory.Build.props`; see "Adopting a new SDK".
+- `--sdk-version-override <version>` on any other target builds against that SDK instead of the one `Directory.Build.props` declares, leaving the file alone: `build.cmd Test --sdk-version-override 2026.2.1` checks a change against another wave, and `build.cmd RunIde --is-rider-host --sdk-version-override 2026.2.1` sandboxes that Rider. NUKE also reads it from the `SDK_VERSION_OVERRIDE` environment variable. The output directories are not keyed by SDK version, so run `build.cmd Clean` when switching the override locally; otherwise the leftovers of the previous SDK are mixed into the build and every test fails in `OneTimeSetUp` with an assembly resolution error. CI starts from a fresh runner and is unaffected.
 - `dotnet sln ReSharper.Structured.Logging.slnx list`: verify that solution project links resolve.
 
 The build requires a compatible .NET SDK; Rider packaging also requires a JDK 17 or newer to run Gradle. The JDK that the Rider build itself compiles against is derived from the target Rider version and provisioned automatically by the Foojay toolchain resolver configured in `settings.gradle`, so it does not need to be installed by hand. Generated output appears in `bin/`, `gradle-build/`, and repository-root package files and must not be committed.
@@ -26,9 +27,25 @@ The published version and the tag are `<SdkVersion>.<workflow run number>`, wher
 
 The corresponding NUKE targets are `PublishReSharperPlugin` and `PublishRiderPlugin --is-rider-host`; both read the token from the `MARKETPLACE_TOKEN` environment variable and refuse to run without it.
 
+## Releasing to the stable wave while master tracks an EAP
+
+`master` follows the prerelease train for most of a cycle, and the whole build derives its identity from that one `SdkVersion` — the version, the `Wave` range the package declares, the Rider `productVersion` and the Marketplace channel — so a release cut from it reaches EAP users only. The `sdk-version` input overrides the SDK for a single run without touching the file:
+
+```
+gh workflow run build.yml --ref master -f publish=true -f sdk-version=2026.2.1
+```
+
+Everything follows the override, so a stable value routes the Rider plugin to the `default` channel and drops the prerelease flag on its own. There is no maintenance branch to cut, and the source cannot drift from the wave it ships for. The same dispatch with `publish=false` is a dry run.
+
+Because the file is untouched, the tagged commit still declares master's SDK; the release notes record the effective one instead. That also keeps the `SdkVersion` push trigger meaning exactly what it means, which is why the value cannot simply be flipped and flipped back — either flip would publish.
+
+A maintenance branch is still the only place a stable fix can live if it ever has to *diverge* from `master`. The input covers the common case where the source is identical.
+
+One thing the default does not get right: GitHub gives the Latest badge to any new stable release, so publishing an override for an *older* wave after a newer stable has shipped takes the badge from it. Correct that with `gh release edit <tag> --latest=false`. Releasing an older wave alongside a *prerelease* is fine, since a prerelease never holds the badge.
+
 ## Adopting a new SDK
 
-The `SDK update` workflow polls nuget.org daily and proposes the bump itself. `build.cmd UpdateSdkVersion` is what it runs: the target reads the versions published for all four SDK packages, keeps only those every one of them has, and picks a target under the wave policy. While the adopted version is stable only a higher wave qualifies, because a same-wave patch is already covered by the `Wave` dependency range the package declares; once it is a prerelease the whole train is followed, `eap01` through `rc01` to the stable release that closes the wave. `--sdk-version-override <version>` adopts a specific version instead, which is the way to take a same-wave patch.
+The `SDK update` workflow polls nuget.org daily and proposes the bump itself. `build.cmd UpdateSdkVersion` is what it runs: the target reads the versions published for all four SDK packages, keeps only those every one of them has, and picks a target under the wave policy. While the adopted version is stable only a higher wave qualifies, because a same-wave patch is already covered by the `Wave` dependency range the package declares; once it is a prerelease the whole train is followed, `eap01` through `rc01` to the stable release that closes the wave. `--sdk-version-override <version>` adopts a specific version instead, which is the way to take a same-wave patch. Note the flag means "use this SDK version instead of the one in `Directory.Build.props`" for every target, and only `UpdateSdkVersion` acts on that by rewriting the file; everywhere else it just builds against the version.
 
 The workflow then commits the bump to `sdk-update/<version>`, opens a pull request with auto-merge enabled, and lets `Build and test` decide. Green merges to `master`, which publishes; red leaves the pull request open, which is the normal outcome for a wave change. Expect to fix binding redirects in `test/src/app.config`, `.gold` expectations, SDK API breaks, and sometimes `build.gradle` and the Gradle wrapper. A stale red pull request is closed as superseded when the next version comes along.
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -6,9 +6,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
-
 using NuGet.Versioning;
-
 using Nuke.Common;
 using Nuke.Common.CI;
 using Nuke.Common.CI.GitHubActions;
@@ -18,7 +16,6 @@ using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.NuGet;
 using Nuke.Common.Tools.NUnit;
 using Nuke.Common.Utilities.Collections;
-
 using static Nuke.Common.EnvironmentInfo;
 using static Nuke.Common.Tools.NUnit.NUnitTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
@@ -31,14 +28,28 @@ class Build : NukeBuild
 
     protected override void OnBuildInitialized()
     {
-        SdkVersion = XDocument
+        SdkVersionFromProps = XDocument
             .Load((RootDirectory / "Directory.Build.props").ToString())
             .Descendants()
             .Single(x => x.Name.LocalName == "SdkVersion")
             .Value;
-        SdkVersion.NotNull("Unable to detect SDK version");
+        SdkVersionFromProps.NotNull("Unable to detect SDK version");
 
-        var versionMatch = Regex.Match(SdkVersion, @"(?<version>[\d\.]+)(?<suffix>-.*)?", RegexOptions.None, RegexTimeout);
+        // Everything a release declares is derived from this one value, so overriding it is all it takes
+        // to build the same source for another wave. The file itself is left alone, which keeps the
+        // SdkVersion push trigger meaning what it means
+        SdkVersion = string.IsNullOrEmpty(SdkVersionOverride) ? SdkVersionFromProps : SdkVersionOverride;
+
+        if (SdkVersion != SdkVersionFromProps)
+        {
+            Serilog.Log.Information(
+                "The effective JetBrains SDK is {Effective}; Directory.Build.props declares {Declared}",
+                SdkVersion,
+                SdkVersionFromProps);
+        }
+
+        var versionMatch = Regex.Match(SdkVersion, @"(?<version>[\d\.]+)(?<suffix>-.*)?", RegexOptions.None,
+            RegexTimeout);
 
         SdkVersionWithoutSuffix = versionMatch.Groups["version"]
             .ToString();
@@ -49,6 +60,7 @@ class Build : NukeBuild
             ? SdkVersion
             : $"{versionMatch.Groups["version"]}.{GitHubActions.RunNumber}{versionMatch.Groups["suffix"]}";
         var sdkMatch = Regex.Match(SdkVersion, @"\d{2}(\d{2}).(\d).*", RegexOptions.None, RegexTimeout);
+        Assert.True(sdkMatch.Success, $"Unable to derive a wave version from the SDK version '{SdkVersion}'");
         WaveMajorVersion = int.Parse(sdkMatch.Groups[1]
             .Value + sdkMatch.Groups[2]
             .Value);
@@ -67,8 +79,10 @@ class Build : NukeBuild
 
     [Parameter] readonly AbsolutePath RunIdeSolution;
 
-    [Parameter("Adopt this SDK version instead of the one the wave policy picks")]
-    readonly string SdkVersionOverride;
+    // UpdateSdkVersion adopts this version into Directory.Build.props; every other target builds against
+    // it and leaves the file alone, which is how a fix reaches the current stable wave while master
+    // follows the EAP train
+    [Parameter("Use this SDK version instead of the one in Directory.Build.props")] readonly string SdkVersionOverride;
 
     [LocalPath("./gradlew.bat")] readonly Tool Gradle;
 
@@ -113,7 +127,8 @@ class Build : NukeBuild
                 var suffix = Regex.Replace(
                     SdkVersionSuffix,
                     @"\d+",
-                    x => int.Parse(x.Value).ToString(),
+                    x => int.Parse(x.Value)
+                        .ToString(),
                     RegexOptions.None,
                     RegexTimeout);
                 productVersion += $"{suffix.ToUpperInvariant()}-SNAPSHOT";
@@ -145,6 +160,10 @@ class Build : NukeBuild
 
     string SdkVersion { get; set; }
 
+    // What the file literally declares, which is what UpdateSdkVersion compares against and reports;
+    // SdkVersion above is the one the build actually uses
+    string SdkVersionFromProps { get; set; }
+
     string SdkVersionSuffix { get; set; }
 
     string SdkVersionWithoutSuffix { get; set; }
@@ -167,6 +186,9 @@ class Build : NukeBuild
                 .SetProjectFile(Project)
                 .SetConfiguration(Configuration)
                 .SetVersionPrefix(ExtensionVersion)
+                // The projects pin their SDK packages to $(SdkVersion), and an override does not rewrite
+                // the file, so a global property is what carries it into the restore
+                .SetProperty("SdkVersion", SdkVersion)
                 .SetOutputDirectory(OutputDirectory));
         });
 
@@ -176,6 +198,9 @@ class Build : NukeBuild
             DotNetBuild(s => s
                 .SetProjectFile(TestProject)
                 .SetConfiguration(Configuration)
+                // The test projects pin the SDK test packages the same way, so without this the plugin
+                // would be tested against one wave and shipped for another
+                .SetProperty("SdkVersion", SdkVersion)
                 .SetOutputDirectory(TestProjectOutputDirectory));
 
             NUnit3(s => s.SetInputFiles(TestProjectOutputDirectory / $"{TestProjectName}.dll"));
@@ -315,10 +340,12 @@ class Build : NukeBuild
         .Executes(async () =>
         {
             var availableVersions = await GetPublishedSdkVersions();
-            var currentVersion = NuGetVersion.Parse(SdkVersion);
+            // This target is the one that changes the file, so it compares against what the file says
+            // rather than against the version an override would have the rest of the build use
+            var currentVersion = NuGetVersion.Parse(SdkVersionFromProps);
 
             NuGetVersion targetVersion;
-            if (SdkVersionOverride != null)
+            if (!string.IsNullOrEmpty(SdkVersionOverride))
             {
                 var requestedVersion = NuGetVersion.Parse(SdkVersionOverride);
                 targetVersion = availableVersions
@@ -332,7 +359,7 @@ class Build : NukeBuild
 
             if (targetVersion == null || targetVersion.Equals(currentVersion))
             {
-                Serilog.Log.Information("The JetBrains SDK {Version} is up to date", SdkVersion);
+                Serilog.Log.Information("The JetBrains SDK {Version} is up to date", SdkVersionFromProps);
                 PublishGitHubOutput("sdk-update-available", "false");
 
                 return;
@@ -348,12 +375,12 @@ class Build : NukeBuild
                 RegexOptions.None,
                 RegexTimeout));
 
-            Serilog.Log.Information("Updated the JetBrains SDK from {Current} to {Target}", SdkVersion, targetVersion);
-            ReportSummary(_ => _.AddPair("SDK", $"{SdkVersion} -> {targetVersion}"));
+            Serilog.Log.Information("Updated the JetBrains SDK from {Current} to {Target}", SdkVersionFromProps, targetVersion);
+            ReportSummary(_ => _.AddPair("SDK", $"{SdkVersionFromProps} -> {targetVersion}"));
 
             PublishGitHubOutput("sdk-update-available", "true");
             PublishGitHubOutput("sdk-version", targetVersion.ToString());
-            PublishGitHubOutput("previous-sdk-version", SdkVersion);
+            PublishGitHubOutput("previous-sdk-version", SdkVersionFromProps);
         });
 
     static async Task<IReadOnlyCollection<NuGetVersion>> GetPublishedSdkVersions()


### PR DESCRIPTION
Closes #184.

While `master` sits on an EAP SDK there was no automated way to ship a fix to the stable wave. Everything a release declares — `ExtensionVersion`, the nuspec `Wave` range, the Rider `productVersion`, the Marketplace channel — derives from the single `SdkVersion` in `Directory.Build.props`, so a release cut from `master` reached EAP users only. The fix for #182 needed a hand-cut `release/2026.2.1` branch whose only delta was that one line.

## What changed

`SdkVersionOverride` now means "use this SDK version instead of the one in `Directory.Build.props`". `UpdateSdkVersion` still *adopts* it; every other target *builds against* it and leaves the file alone. A new `SdkVersionFromProps` holds what the file declares, which is what `UpdateSdkVersion` compares against and reports — the one change that would break silently if missed, since it would otherwise make every dispatched `sdk-update` run report "up to date" and quietly kill the daily automation.

Both `DotNetBuild` calls pass the effective version to MSBuild as a global property, so the four `PackageReference`s pinned to `$(SdkVersion)` follow the override. `Test` needs it as much as `Compile` does, or the plugin would be tested against one wave and shipped for another.

`build.yml` gains an `sdk-version` dispatch input, threaded to NUKE through the `SDK_VERSION_OVERRIDE` environment variable so all six `build.cmd` steps pick it up without repeating it on each line. A stable cut is now one dispatch:

```
gh workflow run build.yml --ref master -f publish=true -f sdk-version=2026.2.1
```

## On the open questions in the issue

**What does the tag point at?** Leaving the file untouched is what keeps the `SdkVersion` push trigger meaning what it means — flipping the value and flipping it back would fire two unwanted publishes. The cost is that the tagged commit no longer records what was built, so the release job now prepends a line to the generated notes naming the effective SDK.

**Should the version be looked up rather than typed?** Typed, matching the input `sdk-update.yml` already has. A wrong value fails at restore in the first step, and a malformed one now fails earlier still with a message, via an assert on the wave regex.

**Is a maintenance branch wanted anyway?** Still the only place a stable fix can live if it ever has to *diverge* from `master`. Documented as such; the input covers the common case where the source is identical.

## Verification

- `build.cmd Test --configuration Release` — 182/182 pass, `--property:SdkVersion=2026.3.0-eap01` emitted alongside `--property:VersionPrefix=`.
- `build.cmd Test --configuration Release --is-rider-host` — 182/182 pass.
- `build.cmd Pack --configuration Release --sdk-version-override 2026.2.1` — produces `ReSharper.Structured.Logging.2026.2.1.nupkg` declaring `<dependency id="Wave" version="262.0.0" />`, i.e. the 2026.2 wave, from a tree whose `Directory.Build.props` says `2026.3.0-eap01`.
- `build.cmd UpdateSdkVersion --sdk-version-override 2026.3.0-eap01` — still reports "up to date" and leaves the file alone; with `2026.2.1` it reports "from 2026.3.0-eap01 to 2026.2.1", confirming `previous` comes from the file rather than the override.
- The release step's bash was dry-run for all three cases: no override (command identical to today's), stable override (adds `--notes`), and EAP (adds `--prerelease`).

`--latest` is deliberately untouched: GitHub never gives the badge to a prerelease, which is why `2026.2.1.89` already holds it over `2026.3.0.88-eap01`. The one case the default gets wrong — an override for an *older* wave published after a newer stable — is documented with the `gh release edit --latest=false` escape hatch.

One local footgun found while testing and written down: the build output directories are not keyed by SDK version, so switching the override locally needs a `Clean` first, or leftovers from the previous SDK mix in and every test fails in `OneTimeSetUp`. CI starts from a fresh runner and is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional SDK version override for builds and releases.
  - Builds can use a specified SDK without modifying project configuration.
  - Release notes include the overridden SDK version when provided.
  - Added clearer validation and reporting when the override differs from the configured SDK.

- **Documentation**
  - Added guidance for using SDK overrides locally and in release workflows.
  - Documented considerations when switching SDK versions and publishing stable releases while tracking an early-access SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->