### PR TITLE
Stop the formatter collapsing import groups on every edit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,8 +5,11 @@ charset = utf-8
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+# Roslyn honours the two dotnet_ keys; the ReSharper formatter behind Rider and its agent hooks
+# reads neither, and collapses the groups on every reformat without the resharper_ one
 dotnet_separate_import_directive_groups = true
 dotnet_sort_system_directives_first = true
+resharper_csharp_blank_lines_between_using_groups = 1
 indent_size = 4
 
 [{*.csproj,*.json,*.yml,*.xml,*.props,*.nuspec,*.config}]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ For Rider frontend and UI code written in Kotlin or Java, use the [IntelliJ Plat
 
 ## Coding Style & Naming Conventions
 
-Follow `.editorconfig`: UTF-8, spaces, final newlines, and trimmed trailing whitespace. Use four-space indentation for C# and Kotlin; use two spaces for project, JSON, YAML, XML, props, and NuSpec files. Keep `System` imports first and separate import groups. Use PascalCase for types and members, `_camelCase` for private C# fields, and descriptive analyzer/highlighting names such as `PropertiesNamingAnalyzer` and `InconsistentLogPropertyNamingWarning`. Preserve the surrounding namespace style when editing older files.
+Follow `.editorconfig`: UTF-8, spaces, final newlines, and trimmed trailing whitespace. Use four-space indentation for C# and Kotlin; use two spaces for project, JSON, YAML, XML, props, and NuSpec files. Keep `System` imports first and separate import groups; `.editorconfig` enforces this for the ReSharper formatter through `resharper_csharp_blank_lines_between_using_groups`, which is what Rider and its agent hooks obey — they ignore the `dotnet_` equivalents, so dropping that key makes every reformat quietly collapse the groups again. Use PascalCase for types and members, `_camelCase` for private C# fields, and descriptive analyzer/highlighting names such as `PropertiesNamingAnalyzer` and `InconsistentLogPropertyNamingWarning`. Preserve the surrounding namespace style when editing older files.
 
 ## Testing Guidelines
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -6,7 +6,9 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+
 using NuGet.Versioning;
+
 using Nuke.Common;
 using Nuke.Common.CI;
 using Nuke.Common.CI.GitHubActions;
@@ -16,6 +18,7 @@ using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.NuGet;
 using Nuke.Common.Tools.NUnit;
 using Nuke.Common.Utilities.Collections;
+
 using static Nuke.Common.EnvironmentInfo;
 using static Nuke.Common.Tools.NUnit.NUnitTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
@@ -375,7 +378,8 @@ class Build : NukeBuild
                 RegexOptions.None,
                 RegexTimeout));
 
-            Serilog.Log.Information("Updated the JetBrains SDK from {Current} to {Target}", SdkVersionFromProps, targetVersion);
+            Serilog.Log.Information("Updated the JetBrains SDK from {Current} to {Target}", SdkVersionFromProps,
+                targetVersion);
             ReportSummary(_ => _.AddPair("SDK", $"{SdkVersionFromProps} -> {targetVersion}"));
 
             PublishGitHubOutput("sdk-update-available", "true");

--- a/test/src/Analyzer/ContextualLoggerPrimaryConstructorAnalyzerTests.cs
+++ b/test/src/Analyzer/ContextualLoggerPrimaryConstructorAnalyzerTests.cs
@@ -1,4 +1,5 @@
 using JetBrains.ReSharper.TestFramework;
+
 using NUnit.Framework;
 
 namespace ReSharper.Structured.Logging.Tests.Analyzer

--- a/test/src/QuickFixes/AddDestructuringToMessageTemplatePropertyFixTests.cs
+++ b/test/src/QuickFixes/AddDestructuringToMessageTemplatePropertyFixTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+
 using ReSharper.Structured.Logging.QuickFixes;
 
 namespace ReSharper.Structured.Logging.Tests.QuickFixes

--- a/test/src/QuickFixes/RemoveTrailingPeriodFixDotNet6Tests.cs
+++ b/test/src/QuickFixes/RemoveTrailingPeriodFixDotNet6Tests.cs
@@ -1,6 +1,8 @@
 using JetBrains.ReSharper.FeaturesTestFramework.Intentions;
 using JetBrains.ReSharper.TestFramework;
+
 using NUnit.Framework;
+
 using ReSharper.Structured.Logging.QuickFixes;
 using ReSharper.Structured.Logging.Tests.Constants;
 


### PR DESCRIPTION
`AGENTS.md` asks for separate import groups, and the codebase agrees: 79 of the 82 multi-group source files have them. Rider's formatter did not — it collapsed the groups on every reformat, so any edit made through an agent hook dragged unrelated import churn into the diff. That showed up in #185.

## Cause

`.editorconfig` already carried `dotnet_separate_import_directive_groups = true`, but that key only reaches Roslyn. The ReSharper formatter behind Rider and its agent hooks reads neither `dotnet_` key and defaults its own count to zero. `resharper_csharp_blank_lines_between_using_groups` is the one it obeys.

Verified by reproducing it: restoring the blank lines and running Rider's reformatter stripped them again; with the key set, they survive both a direct reformat and a real hook-triggered edit.

## Scope

Three files had already been collapsed and are restored, so their next edit does not produce a surprise import diff. One of them (`AddDestructuringToMessageTemplatePropertyFixTests.cs`) came back from a full reformat with collateral — an awkward wrap of its long class declaration and its deliberate compact `[Test] public void …` one-liners split apart — so only the import change was kept there. That file will still reformat on its next hook-triggered edit, because the class name genuinely exceeds the line limit; that is a separate question about line width, not imports.

The 54 collapsed analyzer fixtures under `test/data` are deliberately untouched. Their text is compared against the `.gold` expectations, so moving their imports would break the fixture rather than tidy it — and they sit outside the solution, so Rider's formatter refuses them outright (confirmed: it returns "not part of the current solution"). No `.editorconfig` exclusion was added for them, since guarding a path that cannot be reached is dead configuration.

`build/Build.cs` also picks up a line wrap the formatter wanted on a `Serilog.Log.Information` call that exceeded the limit.

## Verification

- `build.cmd Test --configuration Release` — 182/182 pass.
- Reformatting a fixture is refused by Rider, so the fixtures cannot drift.
- A real `Edit` through the agent hook now leaves the groups intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved formatting consistency for import groups across Roslyn and ReSharper/Rider tooling.
  - Reformatted selected build and test code for clearer spacing and line wrapping.

- **Documentation**
  - Clarified how formatting settings affect import-group preservation in development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->